### PR TITLE
[CJS] An attempt to correctly resolve all kinds of specifiers

### DIFF
--- a/src/cjs-shim.js
+++ b/src/cjs-shim.js
@@ -3,9 +3,12 @@ let modules = {};
 
 function resolve (specifier, parentURL = cS.src) {
 	for (let s in map.imports) {
-		if (specifier === s || specifier.startsWith(s + "/")) {
-			specifier = specifier.replace(s, map.imports[s]);
-			return new URL(specifier, parentURL).href;
+		if (specifier === s) {
+			return new URL(map.imports[s], parentURL).href;
+		}
+		if (s.endsWith("/") && specifier.startsWith(s)) {
+			let target = map.imports[s] + specifier.slice(s.length);
+			return new URL(target, parentURL).href;
 		}
 	}
 
@@ -15,7 +18,10 @@ function resolve (specifier, parentURL = cS.src) {
 function require (specifier, parentURL) {
 	let url = specifier;
 
-	if (!url.startsWith(".") && !url.startsWith("https:")) {
+	if (url.startsWith(".")) {
+		url = new URL(url, parentURL ?? cS.src).href;
+	}
+	else if (!url.startsWith("https:")) {
 		url = resolve(specifier, parentURL);
 	}
 


### PR DESCRIPTION
In the React demo app, relative URLs passed to `localResolve()` don't resolve to URLs relative to the corresponding package folder in client_modules. For example, when we pass `./cjs/react.production.js` as a specifier and `http://localhost:8000/react/client_modules/react@19.2.3/index.js` as a parent URL, we try to request `http://localhost:8000/react/cjs/react.production.js` instead of `http://localhost:8000/react/client_modules/react@19.2.3/cjs/react.production.js`. And, expectedly, we get a 404 error.

This PR tries to fix it and avoid similar issues with other packages.