### PR TITLE
An attempt to handle npm package aliases correctly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,14 @@
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import { getConfig } from "./config.js";
-import { readJSONSync, writeJSONSync, getTopLevelModules, isDirectoryEmptySync } from "./util.js";
+import {
+	readJSONSync,
+	writeJSONSync,
+	getTopLevelModules,
+	isDirectoryEmptySync,
+	getAliasDependencyOverrides,
+	applyAliasOverrides,
+} from "./util.js";
 import {
 	writeFileSync,
 	renameSync,
@@ -267,30 +274,4 @@ export default async function (options) {
 	}
 	info.push(`Import map with ${stats.entries} entries generated successfully at ${config.map}.`);
 	console.log(`[nudeps] ${info.join(" ")}`);
-}
-
-function getAliasDependencyOverrides (pkg) {
-	let deps = pkg?.dependencies;
-	if (!deps) {
-		return null;
-	}
-
-	let overrides = {};
-	for (let [name, spec] of Object.entries(deps)) {
-		if (typeof spec === "string" && spec.startsWith("npm:")) {
-			overrides[name] = `./node_modules/${name}`;
-		}
-	}
-
-	return Object.keys(overrides).length > 0 ? overrides : null;
-}
-
-function applyAliasOverrides (pkg, overrides) {
-	return {
-		...pkg,
-		dependencies: {
-			...(pkg.dependencies ?? {}),
-			...overrides,
-		},
-	};
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,2 +1,3 @@
 export * from "./util/fs.js";
 export * from "./util/paths.js";
+export * from "./util/alias.js";

--- a/src/util/alias.js
+++ b/src/util/alias.js
@@ -1,0 +1,25 @@
+export function getAliasDependencyOverrides (pkg) {
+	let deps = pkg?.dependencies;
+	if (!deps) {
+		return null;
+	}
+
+	let overrides = {};
+	for (let [name, spec] of Object.entries(deps)) {
+		if (typeof spec === "string" && spec.startsWith("npm:")) {
+			overrides[name] = `./node_modules/${name}`;
+		}
+	}
+
+	return Object.keys(overrides).length > 0 ? overrides : null;
+}
+
+export function applyAliasOverrides (pkg, overrides) {
+	return {
+		...pkg,
+		dependencies: {
+			...(pkg.dependencies ?? {}),
+			...overrides,
+		},
+	};
+}


### PR DESCRIPTION
JSPM Generator cannot resolve npm alias specs, so we have to override the root package config with local `node_modules` paths for alias dependencies.

Closes #20.