### PR TITLE
Delete empty parent directories *after* deleting packages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -189,7 +189,6 @@ export default async function (options) {
 
 	for (let parentDir of deleteIfEmpty) {
 		try {
-			console.log("Deleted parent directory", parentDir);
 			rmdirSync(parentDir);
 			stats.deleted++;
 		}


### PR DESCRIPTION
This minimizes I/O since it may be only after deleting several packages that the parent directory is left empty.