### PR TITLE
Fix root package mapping when entry point has missing dependencies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,17 +69,23 @@ export default async function (options) {
 	// We do this AFTER dependency installation because generator.install() regenerates the
 	// import map, which would overwrite any mappings added earlier.
 	// See https://github.com/nudeps/nudeps/issues/30
+	// Note: string prefix match on JSPM error message — may need updating if JSPM changes it.
 	if (rootInstallError?.message.startsWith("Cannot find package")) {
-		let entryPoint = await generator.traceMap.resolver.resolveExport(
-			pathToFileURL(process.cwd() + "/").href,
-			".",
-			false,
-			false,
-			nudeps.pkg.name,
-		);
-		entryPoint = path.relative(process.cwd(), fileURLToPath(entryPoint));
-		entryPoint = entryPoint.startsWith(".") ? entryPoint : `./${entryPoint}`;
-		generator.map.set(nudeps.pkg.name, entryPoint);
+		try {
+			let entryPoint = await generator.traceMap.resolver.resolveExport(
+				pathToFileURL(process.cwd() + "/").href,
+				".",
+				false,
+				false,
+				nudeps.pkg.name,
+			);
+			entryPoint = path.relative(process.cwd(), fileURLToPath(entryPoint));
+			entryPoint = entryPoint.startsWith(".") ? entryPoint : `./${entryPoint}`;
+			generator.map.set(nudeps.pkg.name, entryPoint);
+		}
+		catch (e) {
+			nudeps.error(`Failed to manually resolve root package entry point. ${e.message}`);
+		}
 	}
 
 	if (config.cjs !== false) {


### PR DESCRIPTION
When the root package’s entry point imports packages that aren’t installed, JSPM’s install fails with a “Cannot find package” error. This previously prevented the root package from being added to the import map.

Now we catch this error and manually add the root package mapping after all dependencies are installed, using JSPM’s `resolveExport()` to resolve the entry point. This ensures the root package appears in the import map even when its entry point has missing or uninstalled dependencies.

Fixes #30