### PR TITLE
Fix version resolution for `file:` protocol packages

### DIFF
--- a/src/util/path.js
+++ b/src/util/path.js
@@ -53,12 +53,32 @@ export default class ModulePath {
 		return "node_modules/" + this.packages[0];
 	}
 
+	get lockEntry () {
+		return this.nudeps.packages[this.lockKey];
+	}
+
 	get version () {
-		return this.nudeps.packages[this.lockKey]?.version;
+		let entry = this.lockEntry;
+
+		// file: protocol packages are symlinks in package-lock.json:
+		// their node_modules entry has { link: true, resolved: "<path>" }
+		// but no version — the version is in the entry at the resolved path
+		if (entry?.link) {
+			entry = this.nudeps.packages[entry.resolved];
+		}
+
+		return entry?.version;
 	}
 
 	get packageName () {
-		return this.nudeps.packages[this.lockKey]?.name ?? this.packages.at(-1);
+		let entry = this.lockEntry;
+
+		// Same as version: follow the link to get the actual package name
+		if (entry?.link) {
+			entry = this.nudeps.packages[entry.resolved];
+		}
+
+		return entry?.name ?? this.packages.at(-1);
 	}
 
 	/**

--- a/test/util/paths.js
+++ b/test/util/paths.js
@@ -1,25 +1,34 @@
-import ModulePath from "../../src/util/paths.js";
+import ModulePath from "../../src/util/path.js";
 
-ModulePath.packages = new Proxy(
-	{},
-	{
-		has (target, prop) {
-			return prop.startsWith("node_modules/") || prop in target;
+let mockNudeps = {
+	dir: "./client_modules",
+	packages: new Proxy(
+		{
+			// Simulate a file: protocol (linked) package in package-lock.json
+			"node_modules/linked-pkg": { link: true, resolved: "../../some/path" },
+			"../../some/path": { name: "linked-pkg", version: "4.5.6" },
 		},
-		get (target, prop) {
-			if (prop.startsWith("node_modules/")) {
-				return { version: "1.2.3" };
-			}
-			return target[prop];
+		{
+			has (target, prop) {
+				return prop.startsWith("node_modules/") || prop in target;
+			},
+			get (target, prop) {
+				if (prop in target) {
+					return target[prop];
+				}
+				if (prop.startsWith("node_modules/")) {
+					return { version: "1.2.3" };
+				}
+			},
 		},
-	},
-);
+	),
+};
 
 export default {
 	run (prop) {
 		let path = this.parent.name;
 
-		return new ModulePath(path)[prop];
+		return new ModulePath(path, mockNudeps)[prop];
 	},
 	tests: [
 		{
@@ -143,6 +152,23 @@ export default {
 				{
 					arg: "topNodeDir",
 					expect: "./node_modules/foo",
+				},
+			],
+		},
+		{
+			name: "./node_modules/linked-pkg/dist/index.js",
+			tests: [
+				{
+					arg: "version",
+					expect: "4.5.6",
+				},
+				{
+					arg: "packageName",
+					expect: "linked-pkg",
+				},
+				{
+					arg: "localDir",
+					expect: "./client_modules/linked-pkg@4.5.6",
 				},
 			],
 		},


### PR DESCRIPTION
- Follow symlinks in `package-lock.json` when resolving version and name.
Packages installed via `file:` protocol have `{ link: true, resolved: "<path>"}` in their `node_modules` entry, with the actual metadata at the resolved path.

- Fix test import path (`paths.js` → `path.js`) and pass mock nudeps object to match how `ModulePath` is actually constructed.
- Add test for linked packages.


Fixes #39. All tests pass.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>