### PR TITLE
PackageLock class with link-following resolution

### DIFF
--- a/src/nudeps.js
+++ b/src/nudeps.js
@@ -10,6 +10,7 @@ import { matchesGlob } from "./util/fs.js";
 import { getTopLevelModules } from "./util.js";
 import { existsSync, rmSync, rmdirSync, cpSync } from "node:fs";
 import * as path from "node:path";
+import PackageLock from "./util/package-lock.js";
 
 export default class Nudeps {
 	stats = { entries: 0, copied: 0, deleted: 0, startTime: performance.now() };
@@ -39,10 +40,11 @@ export default class Nudeps {
 	}
 
 	get pkgLock () {
-		let value = readJSONSync("package-lock.json");
-		if (!value) {
+		let data = readJSONSync("package-lock.json");
+		if (!data) {
 			throw new Error("package-lock.json not found or invalid");
 		}
+		let value = new PackageLock(data);
 		Object.defineProperty(this, "pkgLock", { value, configurable: true });
 		return value;
 	}

--- a/src/util/package-lock.js
+++ b/src/util/package-lock.js
@@ -1,0 +1,23 @@
+export default class PackageLock {
+	#resolvedKeys = {};
+
+	constructor (data) {
+		let raw = data.packages ?? {};
+		this.packages = {};
+
+		for (let [key, info] of Object.entries(raw)) {
+			if (info.link) {
+				// Resolve link to the actual package info object
+				this.packages[key] = raw[info.resolved];
+				this.#resolvedKeys[key] = info.resolved;
+			}
+			else {
+				this.packages[key] = info;
+			}
+		}
+	}
+
+	resolveKey (key) {
+		return this.#resolvedKeys[key] ?? key;
+	}
+}

--- a/src/util/path.js
+++ b/src/util/path.js
@@ -1,3 +1,5 @@
+import * as nodePath from "node:path";
+
 export default class ModulePath {
 	nudeps = null;
 	packages = [];
@@ -22,8 +24,12 @@ export default class ModulePath {
 		}
 
 		let index = this.parts.indexOf("node_modules");
+		this.isExternal = index === -1;
 
-		if (index > -1) {
+		if (this.isExternal) {
+			this.base = nodePath.relative(process.cwd(), nodePath.dirname(this.path));
+		}
+		else {
 			this.base = this.parts.splice(0, index).join("/");
 
 			while (this.parts[0] === "node_modules") {
@@ -45,8 +51,16 @@ export default class ModulePath {
 		return this.packages.length > 1;
 	}
 
+	get packageInfo () {
+		return this.nudeps.pkgLock.packages[this.rawLockKey] ?? null;
+	}
+
+	get rawLockKey () {
+		return this.packages.length > 0 ? this.packages.map(pkg => "node_modules/" + pkg).join("/") : this.base;
+	}
+
 	get lockKey () {
-		return this.packages.map(pkg => "node_modules/" + pkg).join("/");
+		return this.nudeps.pkgLock.resolveKey(this.rawLockKey);
 	}
 
 	get topLockKey () {
@@ -54,11 +68,11 @@ export default class ModulePath {
 	}
 
 	get version () {
-		return this.nudeps.packages[this.lockKey]?.version;
+		return this.packageInfo?.version;
 	}
 
 	get packageName () {
-		return this.nudeps.packages[this.lockKey]?.name ?? this.packages.at(-1);
+		return this.packageInfo?.name ?? this.packages.at(-1);
 	}
 
 	/**
@@ -95,9 +109,14 @@ export default class ModulePath {
 	}
 
 	static from (path, nudeps) {
+		if (Array.isArray(path)) {
+			path = path.join("/");
+		}
+
 		if (!this.all[path]) {
 			this.all[path] = new ModulePath(path, nudeps);
 		}
+
 		return this.all[path];
 	}
 }


### PR DESCRIPTION
Resolve link: true entries at construction time into actual object references, so consumers get resolved package info via direct property access instead of following indirection at lookup time.

- PackageLock takes parsed data, resolves links in constructor
- ModulePath delegates to pkgLock.packages[] and pkgLock.resolveKey()
- Nudeps.pkgLock handles file I/O and validation before constructing

This may address the first checkbox here https://github.com/nudeps/nudeps/issues/39#issuecomment-3897679511