### PR TITLE
Fix CLI boolean flags not overriding defaults

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -14,14 +14,18 @@ export default {
 		parse: v => v.split(","),
 		default: [],
 	},
-	prune: {},
+	prune: {
+		default: false,
+	},
 	config: {
 		flag: "c",
 		default: "nudeps.js",
 		validate: v => existsSync(v),
 		file: false,
 	},
-	init: {},
+	init: {
+		default: false,
+	},
 	overrides: {
 		cli: false,
 	},


### PR DESCRIPTION
`--prune=false` and `--init=false` were kept as strings because `readArgs()` only coerces `”true”`/`”false"` strings when the option has a boolean default. Add the missing `default: false` to both.

Rel. to #50.