### PR TITLE
Respect symlink parameter for existing folders

### DIFF
--- a/src/nudeps.js
+++ b/src/nudeps.js
@@ -29,9 +29,9 @@ export default class Nudeps {
 		this.config = config;
 		this.oldConfig = readJSONSync(".nudeps/config.json");
 
-		this.existingDirs = new Set(
-			config.init ? [] : getTopLevelModules(config.dir).map(d => config.dir + "/" + d),
-		);
+		let { dirs, symlinks } = config.init ? { dirs: [], symlinks: [] } : getTopLevelModules(config.dir);
+		this.existingDirs = new Set(dirs.map(d => config.dir + "/" + d));
+		this.existingSymlinks = new Set(symlinks.map(d => config.dir + "/" + d));
 		this.toDelete = new Set(this.existingDirs);
 		this.hasIgnoreExceptions = this.config.ignore.some(p => p.include);
 		this.hasDeepGlobs = this.config.ignore.some(p => (p.include ?? p.exclude)?.includes("/"));
@@ -177,14 +177,22 @@ export default class Nudeps {
 	}
 
 	copyPackages () {
-		let { config, existingDirs, toCopy, toDelete, toDeleteIfEmpty, stats } = this;
+		let { config, existingDirs, existingSymlinks, toCopy, toDelete, toDeleteIfEmpty, stats } = this;
 
 		// Copy (or symlink) package directories
 		for (let from in toCopy) {
 			let to = toCopy[from];
 			let mp = this.path(from);
 
-			if (existingDirs.has(to)) {
+			let exists = existingDirs.has(to);
+			let needsRecreate = exists && (existingSymlinks.has(to) !== this.shouldSymlink(mp));
+
+			if (needsRecreate) {
+				rmSync(to, { recursive: true });
+				toDelete.delete(to);
+			}
+
+			if (exists && !needsRecreate) {
 				toDelete.delete(to);
 			}
 			else if (this.shouldSymlink(mp)) {

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -4,7 +4,6 @@ import {
 	existsSync,
 	mkdirSync,
 	readdirSync,
-	statSync,
 	opendirSync,
 	symlinkSync,
 	readlinkSync,
@@ -25,19 +24,25 @@ export function writeJSONSync (path, data, indent = "\t") {
 	return writeFileSync(path, JSON.stringify(data, null, indent));
 }
 
+/**
+ * Read a directory's contents, returning entries with name and symlink info.
+ * Uses `withFileTypes` to avoid separate `statSync` calls.
+ * @param {string} directory
+ * @param {{ type?: "directory" | "file" }} [options]
+ * @returns {{ name: string, isSymlink: boolean }[]}
+ */
 export function readDirectorySync (directory, { type } = {}) {
 	try {
-		// TODO use withFileTypes option instead of filtering by statSync after
-		let ret = readdirSync(directory);
+		let entries = readdirSync(directory, { withFileTypes: true });
 
-		if (type) {
-			ret = ret.filter(item =>
-				statSync(path.join(directory, item))[
-					type === "directory" ? "isDirectory" : "isFile"
-				]());
+		if (type === "directory") {
+			entries = entries.filter(d => d.isDirectory() || d.isSymbolicLink());
+		}
+		else if (type === "file") {
+			entries = entries.filter(d => d.isFile());
 		}
 
-		return ret;
+		return entries.map(d => ({ name: d.name, isSymlink: d.isSymbolicLink() }));
 	}
 	catch (e) {
 		if (e.code === "ENOENT") {
@@ -48,16 +53,30 @@ export function readDirectorySync (directory, { type } = {}) {
 	}
 }
 
+/**
+ * Get all top-level modules in a directory, handling scoped packages.
+ * @param {string} [directory]
+ * @returns {{ dirs: string[], symlinks: string[] }} `symlinks` is a subset of `dirs`
+ */
 export function getTopLevelModules (directory = "./node_modules") {
-	return readDirectorySync(directory, { type: "directory" }).flatMap(dir => {
-		if (dir[0] === "@") {
-			return readDirectorySync(path.join(directory, dir), { type: "directory" }).flatMap(
-				subdir => `${dir}/${subdir}`,
-			);
-		}
+	let dirs = [];
+	let symlinks = [];
 
-		return dir;
-	});
+	for (let { name, isSymlink } of readDirectorySync(directory, { type: "directory" })) {
+		if (name[0] === "@") {
+			for (let sub of readDirectorySync(path.join(directory, name), { type: "directory" })) {
+				let full = `${name}/${sub.name}`;
+				dirs.push(full);
+				if (sub.isSymlink) symlinks.push(full);
+			}
+		}
+		else {
+			dirs.push(name);
+			if (isSymlink) symlinks.push(name);
+		}
+	}
+
+	return { dirs, symlinks };
 }
 
 export function isDirectoryEmptySync (path) {


### PR DESCRIPTION
## Summary

Fixes #55. Alternative to #56.

When switching between modes (e.g. dev → prod), existing entries in `client_modules` retained their old type — symlinks stayed as symlinks, real copies stayed as copies — ignoring the `symlink` config parameter.

### Approach

PR #56 fixes this by adding an `lstatSync` call per entry during the copy loop. This PR takes a different approach: get symlink info **upfront** from the directory read itself, with zero extra syscalls.

- `readDirectorySync` now uses `readdirSync({ withFileTypes: true })` (resolving an existing TODO), which returns `Dirent` objects with both `isDirectory()` and `isSymbolicLink()` — exactly the info we need, in one call
- `getTopLevelModules` returns `{ dirs, symlinks }` so the constructor can build both `existingDirs` and `existingSymlinks` sets in one pass
- `copyPackages` detects type mismatches (symlink vs real copy) and removes the entry before recreating it with the correct type

This is better than the `lstatSync`-per-entry approach because the kernel already returns file type info in the `getdents` syscall that `readdirSync` uses — `withFileTypes` just exposes it. No extra syscalls needed.

## Test plan

- [x] Run with `symlink: true` → verify symlinks in `client_modules`
- [x] Switch to `symlink: false`, run again → verify symlinks replaced with real copies
- [x] Switch back to `symlink: true` → verify copies replaced with symlinks
- [x] Run with `--init` → verify clean build works

🤖 Generated with [Claude Code](https://claude.com/claude-code)