### PR TITLE
Add `external` option for CDN packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ For background, see [Web dependencies are broken. Can we fix them?](https://lea.
 6. [Config options](#config-options)
 	1. [Restricting which files are deployed from dependencies](#restricting-which-files-are-deployed-from-dependencies)
 	2. [Aliases](#aliases)
-	3. [Modes](#modes)
-	4. [Pruning (`nudeps --prune`)](#pruning-nudeps---prune)
-	5. [Force initialization (`nudeps --init`)](#force-initialization-nudeps---init)
+	3. [External packages](#external-packages)
+	4. [Modes](#modes)
+	5. [Pruning (`nudeps --prune`)](#pruning-nudeps---prune)
+	6. [Force initialization (`nudeps --init`)](#force-initialization-nudeps---init)
 7. [Local dependencies](#local-dependencies)
 	1. [Registration](#registration)
 	2. [Propagation](#propagation)
@@ -207,6 +208,7 @@ Some command line options also allow for a shorthand one letter syntax (e.g. `-d
 | Module               | `module`        | `--module`  | -              | `false`            | Set to `true` if the import map script will be loaded as `<script type="module">`. Please note that **this will reduce browser support**, as certain browsers do not support injecting import maps after any module has started loading.                                     |
 | CommonJS             | `cjs`           | `--cjs`     | -              | `true`             | Whether to add a CommonJS shim to the import if any CJS packages are detected. Setting to `false` will omit both the shim and these packages from the import map.                                                                                                            |
 | Alias                | `alias`         | `--alias`   | -              | -                  | Create unversioned symlinks in `client_modules` pointing to versioned directories. Useful for stable URLs to package assets (CSS, images, etc.). See [Aliases](#aliases) below.                                                                                              |
+| External             | `external`      | -           | -              | `{}`               | Serve specific packages from a CDN instead of locally. Useful for packages that can't run in the browser from local files (CJS-only, Node built-in deps, etc.). See [External packages](#external-packages) below.                                                           |
 
 ### Restricting which files are deployed from dependencies
 
@@ -293,6 +295,63 @@ When an alias is removed from the config (or its package is uninstalled), the sy
 
 > **npm aliases:** When using npm aliases (e.g. `npm install my-props@npm:open-props`), string and object forms match against both the install name (`my-props`) and the real package name (`open-props`), with install name taking priority in object lookups.
 > Function forms receive both as `{ packageName, version, installName }`, letting you distinguish multiple installs of the same package.
+
+### External packages
+
+Some npm packages can't run locally in the browser — they may be CJS-only, depend on Node built-ins, or have other incompatibilities.
+The `external` option lets you serve these packages from a CDN instead.
+External packages are excluded from `client_modules/` and resolved via CDN URLs in the import map.
+
+Under the hood, nudeps uses [JSPM's CDN provider system](https://jspm.org/docs/generator/interfaces/GeneratorOptions.html) to trace subpaths and build proper scopes for external packages.
+The default provider is `esm.sh`, which handles CJS→ESM conversion automatically.
+
+Supported providers: `"esm.sh"`, `"jspm.io"`, `"jspm.io#system"`, `"jsdelivr"`, `"unpkg"`, `"skypack"`.
+
+The `external` option supports several forms:
+
+**String** — one package, default provider:
+
+```js
+external: "pg"
+```
+
+**Array** — multiple packages, default provider:
+
+```js
+external: ["pg", "better-sqlite3"]
+```
+
+**Object** — per-package provider:
+
+```js
+external: {
+	"pg": true,          // default provider (esm.sh)
+	"lodash": "jsdelivr" // specific provider
+}
+```
+
+Functions can also be used as object values for per-package logic:
+
+```js
+external: {
+	"pg": ({ version }) => "esm.sh"
+}
+```
+
+**Function** — dynamic for all packages:
+
+```js
+// Mark all packages starting with "pg" as external
+external: (ctx) => ctx.packageName.startsWith("pg")
+```
+
+Function forms receive `{ packageName, installName, version }` and should return `true` (default provider), a provider name string, or a falsy value.
+
+> **npm aliases:** When using npm aliases (e.g. `npm install my-pg@npm:pg`), string and object forms match against both the install name (`my-pg`) and the real package name (`pg`), with install name taking priority in object lookups.
+
+> **Transitive dependencies:** The CDN provider resolves all transitive dependencies of external packages through the CDN itself, using scoped import map entries.
+> This means if an external package and a local package share a transitive dependency (e.g. both use `lodash`), it will be loaded twice — once locally and once from the CDN.
+> This is an inherent tradeoff of the external escape hatch and is generally negligible in practice.
 
 ### Modes
 

--- a/src/index.js
+++ b/src/index.js
@@ -48,9 +48,10 @@ export default async function (options) {
 
 	if (!config.prune && nudeps.pkg.dependencies) {
 		let exclude = new Set(config.exclude ?? []);
+		let external = nudeps.externalPackages;
 
 		for (const dep in nudeps.pkg.dependencies) {
-			if (exclude.has(dep)) {
+			if (exclude.has(dep) || external.has(dep)) {
 				continue;
 			}
 
@@ -117,6 +118,9 @@ export default async function (options) {
 		}
 	}
 
+	// Install external packages from CDN providers
+	let cdnMap = await nudeps.installExternalPackages();
+
 	let dirExists = existsSync(config.dir);
 	if (config.init && dirExists) {
 		rmSync(config.dir, { recursive: true });
@@ -134,6 +138,12 @@ export default async function (options) {
 	let { toCopy } = nudeps;
 
 	const { map, stats } = nudeps;
+
+	// Merge CDN entries into the local map (CDN URLs don't contain node_modules/,
+	// so the rewrite loop below naturally skips them)
+	if (cdnMap.imports || cdnMap.scopes) {
+		map.applyOverrides(cdnMap);
+	}
 
 	for (let { specifier, url, map: subMap } of map) {
 		stats.entries++;

--- a/src/map.js
+++ b/src/map.js
@@ -9,13 +9,17 @@ import * as path from "node:path";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export class ImportMapGenerator extends Generator {
-	constructor ({ mode, ...generatorOptions } = {}) {
+	constructor ({ mode, ignore, ...generatorOptions } = {}) {
 		if (mode) {
 			this.mode = mode;
 			generatorOptions.env ??= [mode, "browser", "module"];
 		}
 
 		let commonJS = generatorOptions.commonJS ?? true;
+		let allIgnore = getNodeBuiltins();
+		if (ignore) {
+			allIgnore = allIgnore.concat(ignore);
+		}
 
 		super({
 			defaultProvider: "nodemodules",
@@ -23,7 +27,7 @@ export class ImportMapGenerator extends Generator {
 			flattenScopes: false,
 			combineSubpaths: "both",
 			commonJS: true,
-			ignore: getNodeBuiltins(),
+			ignore: allIgnore,
 			...generatorOptions,
 		});
 
@@ -196,6 +200,21 @@ ${injectMap}
 })();
 `;
 	}
+}
+
+/**
+ * Deep-merge multiple `{ imports, scopes }` import map objects into one.
+ * @param {...object} maps - Import map objects to merge (later ones take precedence)
+ * @returns {object} Merged import map
+ */
+export function mergeImportMaps (...maps) {
+	let result = {};
+	for (let map of maps) {
+		if (map) {
+			deepAssign(result, map);
+		}
+	}
+	return result;
 }
 
 function deepAssign (target, source) {

--- a/src/nudeps.js
+++ b/src/nudeps.js
@@ -3,7 +3,7 @@
  */
 
 import { readJSONSync } from "./util.js";
-import { ImportMapGenerator, ImportMap } from "./map.js";
+import { ImportMapGenerator, ImportMap, mergeImportMaps } from "./map.js";
 import ModulePath from "./util/path.js";
 import { matchesGlob, ensureSymlink } from "./util/fs.js";
 
@@ -11,6 +11,8 @@ import { getTopLevelModules } from "./util.js";
 import { existsSync, rmSync, rmdirSync, cpSync, symlinkSync, mkdirSync } from "node:fs";
 import * as path from "node:path";
 import PackageLock from "./util/package-lock.js";
+
+const DEFAULT_PROVIDER = "esm.sh";
 
 export default class Nudeps {
 	stats = {
@@ -53,6 +55,13 @@ export default class Nudeps {
 	get generator () {
 		let generatorOptions = { commonJS: this.config.cjs };
 
+		// Tell JSPM to ignore external packages so it doesn't resolve them locally;
+		// other packages that depend on them fall back to top-level import map entries
+		let externalNames = [...this.externalPackages.keys()];
+		if (externalNames.length > 0) {
+			generatorOptions.ignore = externalNames;
+		}
+
 		let value = new ImportMapGenerator(generatorOptions);
 		Object.defineProperty(this, "generator", { value, configurable: true });
 		return value;
@@ -68,6 +77,132 @@ export default class Nudeps {
 
 		Object.defineProperty(this, "map", { value, configurable: true });
 		return value;
+	}
+
+	/**
+	 * Resolve the external provider for a dependency.
+	 * Returns a provider name string (e.g. "esm.sh") or null if the dep is not external.
+	 * @param {string} dep - The install name (key under pkg.dependencies)
+	 * @param {*} [external] - External config value; defaults to this.config.external
+	 * @returns {string|null}
+	 */
+	resolveExternal (dep, external = this.config.external) {
+		let lockKey = `node_modules/${dep}`;
+		let info = this.pkgLock.packages[lockKey];
+		let installName = dep;
+		let packageName = info?.name ?? dep;
+		let version = info?.version;
+
+		return this.#resolveExternalValue(external, { installName, packageName, version });
+	}
+
+	/**
+	 * Recursively resolve an external config value for a given package context.
+	 * Supports true, string (package name match), array, object (key lookup), and function forms.
+	 * After object/function fall-through: true → default provider, string → provider name.
+	 */
+	#resolveExternalValue (value, ctx) {
+		if (value == null || value === false) return null;
+		if (value === true) return DEFAULT_PROVIDER;
+
+		if (Array.isArray(value)) {
+			for (let item of value) {
+				let result = this.#resolveExternalValue(item, ctx);
+				if (result) return result;
+			}
+			return null;
+		}
+
+		// Top-level string = match by package name
+		if (typeof value === "string") {
+			return ctx.installName === value || ctx.packageName === value ? DEFAULT_PROVIDER : null;
+		}
+
+		// Object form: key lookup, then fall through
+		if (typeof value === "object") {
+			value = value[ctx.installName] ?? value[ctx.packageName];
+		}
+
+		// Function form (top-level or object value)
+		if (typeof value === "function") {
+			value = value(ctx);
+		}
+
+		// Fall-through resolution: true → default, string → provider name
+		if (value === true) return DEFAULT_PROVIDER;
+		if (typeof value === "string") return value;
+		return null;
+	}
+
+	/**
+	 * Map of external packages: installName → { provider, packageName, version }.
+	 * Iterates pkg.dependencies and resolves each against the external config.
+	 */
+	get externalPackages () {
+		let result = new Map();
+		let deps = this.pkg.dependencies;
+
+		if (deps) {
+			for (let dep in deps) {
+				let provider = this.resolveExternal(dep);
+				if (provider) {
+					let info = this.pkgLock.packages[`node_modules/${dep}`];
+					result.set(dep, {
+						provider,
+						packageName: info?.name ?? dep,
+						version: info?.version,
+					});
+				}
+			}
+		}
+
+		Object.defineProperty(this, "externalPackages", { value: result, configurable: true });
+		return result;
+	}
+
+	/**
+	 * Install external packages from CDN providers.
+	 * Groups packages by provider, creates a separate ImportMapGenerator per provider,
+	 * installs each package, and returns the merged import map.
+	 * @returns {Promise<object>} Merged { imports, scopes } from all CDN generators
+	 */
+	async installExternalPackages () {
+		if (this.externalPackages.size === 0) return {};
+
+		// Group by provider
+		let groups = {};
+		for (let [installName, { provider, packageName, version }] of this.externalPackages) {
+			groups[provider] ??= [];
+			groups[provider].push({ installName, packageName, version });
+		}
+
+		let maps = [];
+
+		for (let [providerName, packages] of Object.entries(groups)) {
+			let generator = new ImportMapGenerator({
+				defaultProvider: providerName,
+				commonJS: this.config.cjs,
+			});
+
+			for (let { installName, packageName, version } of packages) {
+				let target = version ? `${packageName}@${version}` : packageName;
+
+				if (!version) {
+					this.info(`Warning: No version found for external package ${installName}, using latest`);
+				}
+
+				try {
+					await generator.install(installName, target);
+				}
+				catch (e) {
+					this.error(`Error installing external package ${installName} from ${providerName}: ${e.message}`);
+				}
+			}
+
+			maps.push(generator.getMap());
+		}
+
+		return mergeImportMaps(...maps);
 	}
 
 	#childLocks = {};

--- a/src/options.js
+++ b/src/options.js
@@ -80,4 +80,5 @@ export default {
 		default: false,
 	},
 	alias: {},
+	external: {},
 };


### PR DESCRIPTION
I’m not sure if this is worth it, so I’m going to leave this here as a PR.

## Summary

- Adds `external` option to serve incompatible packages (CJS-only, Node built-in deps, etc.) from CDN providers instead of copying locally
- Uses JSPM's CDN provider system to trace subpaths and build proper scopes per provider
- Supports string, array, object, and function forms (mirrors `alias` API)
- Default provider is `esm.sh`; also supports `jspm.io`, `jsdelivr`, `unpkg`, `skypack`
- Fixes a latent bug where caller-provided `ignore` arrays would overwrite node builtins in `ImportMapGenerator`

Fixes #16

## Test plan

- [ ] Run against a demo project with a known-problematic package marked as `external`
- [ ] Verify: package absent from `client_modules/`, CDN URLs present in import map with proper scopes
- [ ] Verify: other local packages that import the external one resolve correctly via top-level entries
- [ ] Test all config forms: string, array, object (with `true`/provider/function values), top-level function
- [ ] Test with npm aliases (install name vs package name matching)
- [ ] Test with no `external` config (default `{}`) — no behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)