### PR TITLE
Fix lockfile fallback: prefer package-lock.json, fall back to hidden lockfile

### DIFF
--- a/src/nudeps.js
+++ b/src/nudeps.js
@@ -30,7 +30,9 @@ export default class Nudeps {
 		this.config = config;
 		this.oldConfig = readJSONSync(".nudeps/config.json", { optional: true });
 
-		let { dirs, symlinks } = config.init ? { dirs: [], symlinks: [] } : getTopLevelModules(config.dir);
+		let { dirs, symlinks } = config.init
+			? { dirs: [], symlinks: [] }
+			: getTopLevelModules(config.dir);
 		this.existingDirs = new Set(dirs.map(d => config.dir + "/" + d));
 		this.existingSymlinks = new Set(symlinks.map(d => config.dir + "/" + d));
 		this.toDelete = new Set(this.existingDirs);
@@ -45,11 +47,14 @@ export default class Nudeps {
 	}
 
 	get pkgLock () {
-		if (!existsSync("node_modules") && existsSync("package.json")) {
-			throw new Error("node_modules not found. Run `npm install` first.");
+		let data =
+			readJSONSync("package-lock.json", { optional: true }) ??
+			readJSONSync("node_modules/.package-lock.json", { optional: true });
+
+		if (!data) {
+			throw new Error("No lockfile found. Run `npm install` first.");
 		}
 
-		let data = readJSONSync("node_modules/.package-lock.json");
 		let value = new PackageLock(data);
 		Object.defineProperty(this, "pkgLock", { value, configurable: true });
 		return value;
@@ -85,28 +90,25 @@ export default class Nudeps {
 	 */
 	childLock (resolvedPath) {
 		if (!(resolvedPath in this.#childLocks)) {
-			let nmDir = `${resolvedPath}/node_modules`;
+			let data =
+				readJSONSync(`${resolvedPath}/package-lock.json`, { optional: true }) ??
+				readJSONSync(`${resolvedPath}/node_modules/.package-lock.json`, { optional: true });
 
-			if (!existsSync(nmDir) && existsSync(`${resolvedPath}/package.json`)) {
-				this.info(`Warning: node_modules not found at ${resolvedPath}. Run \`npm install\` there first.`);
+			if (!data) {
+				this.info(
+					`Warning: No lockfile found at ${resolvedPath}. Run \`npm install\` there first.`,
+				);
 				this.#childLocks[resolvedPath] = null;
 			}
 			else {
-				let data = readJSONSync(`${nmDir}/.package-lock.json`, { optional: true });
-				if (data) {
-					this.#childLocks[resolvedPath] = new PackageLock(data);
-				}
-				else {
-					this.info(`Warning: No lockfile found at ${resolvedPath}`);
-					this.#childLocks[resolvedPath] = null;
-				}
+				this.#childLocks[resolvedPath] = new PackageLock(data);
 			}
 		}
 		return this.#childLocks[resolvedPath];
 	}
 
 	get packages () {
-		return this.pkgLock?.packages ?? {};
+		return this.pkgLock.packages;
 	}
 
 	get dir () {
@@ -185,7 +187,8 @@ export default class Nudeps {
 	}
 
 	copyPackages () {
-		let { config, existingDirs, existingSymlinks, toCopy, toDelete, toDeleteIfEmpty, stats } = this;
+		let { config, existingDirs, existingSymlinks, toCopy, toDelete, toDeleteIfEmpty, stats } =
+			this;
 
 		// Copy (or symlink) package directories
 		for (let from in toCopy) {
@@ -193,7 +196,7 @@ export default class Nudeps {
 			let mp = this.path(from);
 
 			let exists = existingDirs.has(to);
-			let needsRecreate = exists && (existingSymlinks.has(to) !== this.shouldSymlink(mp));
+			let needsRecreate = exists && existingSymlinks.has(to) !== this.shouldSymlink(mp);
 
 			if (needsRecreate) {
 				rmSync(to, { recursive: true });
@@ -247,7 +250,12 @@ export default class Nudeps {
 						toDelete.delete(aliasPath);
 					}
 
-					if (ensureSymlink(relTarget, aliasPath, "dir", { force: exists, skipIfCorrect: exists })) {
+					if (
+						ensureSymlink(relTarget, aliasPath, "dir", {
+							force: exists,
+							skipIfCorrect: exists,
+						})
+					) {
 						stats.aliased++;
 					}
 				}


### PR DESCRIPTION
## Summary

- **`pkgLock` getter**: tries `package-lock.json` first, falls back to `node_modules/.package-lock.json`, throws if neither exists
- **`childLock()`**: same fallback chain, warns + returns null if neither exists (non-fatal for a dependency)
- **`packages` getter**: removed dead `?.` / `?? {}` since `pkgLock` is guaranteed non-null
- Cleaned up `childLock()` by removing redundant `existsSync` checks (`readJSONSync` with `optional: true` handles that)

## Context

Commit ee03cc1 switched entirely from `package-lock.json` to `node_modules/.package-lock.json` to fix #64 (crash when `package-lock.json` is absent/gitignored). However, it went too far — it completely replaced the source rather than adding a fallback.

The hidden lockfile only exists when `node_modules` is present. If someone has `package-lock.json` committed but hasn't run `npm install` yet (e.g. fresh clone), the previous code threw an error instead of reading the available lockfile.

## Analysis

Both lockfile formats produce identical results for all edge cases:

- **Local packages** (`link: true`): identical entries in both files (verified with React and Vue demos)
- **Git dependencies**: no `link` property, treated as regular packages in both formats
- **npm aliases**: same — no `link` property, handled identically
- **Root `""` entry**: only in `package-lock.json`, but has no `link: true` so it's harmlessly stored and never looked up

The only structural difference is the root `""` entry, which doesn't affect any code path.

## Test plan

- [x] All 58 existing tests pass
- [ ] Test with `package-lock.json` present, `node_modules` absent (fresh clone scenario)
- [ ] Test with `package-lock.json` absent, `node_modules` present (gitignored lockfile scenario)
- [ ] Test with demo projects (`nudeps-demos/vue`, `nudeps-demos/react`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)