### PR TITLE
Fix lockfile fallback: prefer package-lock.json, fall back to hidden lockfile

### DIFF
--- a/src/nudeps.js
+++ b/src/nudeps.js
@@ -45,11 +45,14 @@ export default class Nudeps {
 	}
 
 	get pkgLock () {
-		if (!existsSync("node_modules") && existsSync("package.json")) {
-			throw new Error("node_modules not found. Run `npm install` first.");
+		let data =
+			readJSONSync("package-lock.json", { optional: true }) ??
+			readJSONSync("node_modules/.package-lock.json", { optional: true });
+
+		if (!data) {
+			throw new Error("No lockfile found. Run `npm install` first.");
 		}
 
-		let data = readJSONSync("node_modules/.package-lock.json");
 		let value = new PackageLock(data);
 		Object.defineProperty(this, "pkgLock", { value, configurable: true });
 		return value;
@@ -85,28 +88,25 @@ export default class Nudeps {
 	 */
 	childLock (resolvedPath) {
 		if (!(resolvedPath in this.#childLocks)) {
-			let nmDir = `${resolvedPath}/node_modules`;
+			let data =
+				readJSONSync(`${resolvedPath}/package-lock.json`, { optional: true }) ??
+				readJSONSync(`${resolvedPath}/node_modules/.package-lock.json`, { optional: true });
 
-			if (!existsSync(nmDir) && existsSync(`${resolvedPath}/package.json`)) {
-				this.info(`Warning: node_modules not found at ${resolvedPath}. Run \`npm install\` there first.`);
+			if (!data) {
+				this.info(
+					`Warning: No lockfile found at ${resolvedPath}. Run \`npm install\` there first.`,
+				);
 				this.#childLocks[resolvedPath] = null;
 			}
 			else {
-				let data = readJSONSync(`${nmDir}/.package-lock.json`, { optional: true });
-				if (data) {
-					this.#childLocks[resolvedPath] = new PackageLock(data);
-				}
-				else {
-					this.info(`Warning: No lockfile found at ${resolvedPath}`);
-					this.#childLocks[resolvedPath] = null;
-				}
+				this.#childLocks[resolvedPath] = new PackageLock(data);
 			}
 		}
 		return this.#childLocks[resolvedPath];
 	}
 
 	get packages () {
-		return this.pkgLock?.packages ?? {};
+		return this.pkgLock.packages;
 	}
 
 	get dir () {


### PR DESCRIPTION
## Summary

- **`pkgLock` getter**: tries `package-lock.json` first, falls back to `node_modules/.package-lock.json`, throws if neither exists
- **`childLock()`**: same fallback chain, warns + returns null if neither exists (non-fatal for a dependency)
- **`packages` getter**: removed dead `?.` / `?? {}` since `pkgLock` is guaranteed non-null
- Cleaned up `childLock()` by removing redundant `existsSync` checks (`readJSONSync` with `optional: true` handles that)

## Context

Commit ee03cc1 switched entirely from `package-lock.json` to `node_modules/.package-lock.json` to fix #64 (crash when `package-lock.json` is absent/gitignored). However, it went too far — it completely replaced the source rather than adding a fallback.

The hidden lockfile only exists when `node_modules` is present. If someone has `package-lock.json` committed but hasn't run `npm install` yet (e.g. fresh clone), the previous code threw an error instead of reading the available lockfile.

## Analysis

Both lockfile formats produce identical results for all edge cases:

- **Local packages** (`link: true`): identical entries in both files (verified with React and Vue demos)
- **Git dependencies**: no `link` property, treated as regular packages in both formats
- **npm aliases**: same — no `link` property, handled identically
- **Root `""` entry**: only in `package-lock.json`, but has no `link: true` so it's harmlessly stored and never looked up

The only structural difference is the root `""` entry, which doesn't affect any code path.

## Test plan

- [x] All 58 existing tests pass
- [x] `package-lock.json` present, `node_modules` absent — reads lockfile, runs gracefully
- [x] `package-lock.json` absent, `node_modules` present — falls back to hidden lockfile, full success
- [x] Demo projects (`nudeps-demo/vue`, `nudeps-demo/react`) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>