### PR TITLE
Fix CJS shim regression introduced in #79

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -37,7 +37,7 @@ export class ImportMapGenerator extends Generator {
 		this.staleCacheKeys = new Set(Object.keys(installCache ?? {}));
 		this.stats = { cacheHits: 0, cacheMisses: 0 };
 		// Save options for creating temp generators on cache miss
-		this._options = { mode, ...generatorOptions };
+		this._options = { mode, nudeps, ...generatorOptions };
 
 		// Apply JSPM community overrides (client-side equivalent of what jspm.io CDN does server-side)
 		let pm = this.provider;
@@ -78,6 +78,7 @@ export class ImportMapGenerator extends Generator {
 			this.stats.cacheMisses++;
 			let tempGen = new ImportMapGenerator(this._options);
 			await tempGen.install(alias, target, { noRetry, ...installOptions });
+			await tempGen.finalize();
 
 			let depMap = tempGen.getMap();
 			this.installCache[cacheKey] = depMap;


### PR DESCRIPTION
## Summary

The caching temp generators introduced in #79 were missing the \`nudeps\` reference needed to detect CJS packages, and \`finalize()\` was never called on them to resolve the shim, so cache misses silently skipped CJS handling.

**Fix:** pass \`nudeps\` in \`_options\` and call \`finalize()\` on temp generators.

## Test plan

- [x] First run (cache miss): CJS detected, shim installed on temp generator, cached with dep map
- [x] Second run (cache hit): shim found in cached map, import map identical
- [x] All unit tests pass