### PR TITLE
Add AI agent skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,4 @@
 - Demos you can use to test stuff in ../nudeps-demos/
 - When running tests via `npx htest`, pass `--verbose` to see output for passing tests (htest suppresses output in non-TTY/piped contexts unless there are failures or `--verbose` is set).
 - In addition to running tests, also `npm run demos` or `npm run init-demos` to regenerate all import maps.
+- `SKILL.md` is an AI agent skill that ships with the package. After any code change, check if `SKILL.md` needs a corresponding update to stay accurate.

--- a/README.md
+++ b/README.md
@@ -154,17 +154,15 @@ If something seems off, you can run `npx nudeps` explicitly, but most of the tim
 
 ### AI coding assistants
 
-If you use AI coding assistants like [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [GitHub Copilot](https://github.com/features/copilot), [Cursor](https://www.cursor.com/), etc., you may want to add the following to your project's `CLAUDE.md` and/or `AGENTS.md` so that the AI understands nudeps' workflow and doesn't try to run it manually:
+Nudeps ships with a [`SKILL.md`](SKILL.md) — a comprehensive reference that teaches AI coding agents how to work with nudeps correctly (lifecycle hooks, generated artifacts, CJS handling, common mistakes, etc.).
 
-```markdown
-## nudeps (dependency management)
+The easiest way to install it is via the [`skills`](https://github.com/nicepkg/skills) CLI, which supports 45+ agents including Claude Code, Cursor, and Copilot:
 
-- **Do NOT run `npx nudeps` after `npm install` or `npm uninstall`** — it runs automatically via an npm lifecycle hook (`dependencies` script in package.json).
-- The `dependencies` script in package.json is an npm hook that fires automatically after install/uninstall — do not modify or call it manually.
-- `client_modules/` and `importmap.js` are generated artifacts managed by nudeps. Do not edit them.
-- Only run `npx nudeps` explicitly if the import map seems out of sync.
-- To add/remove a client-side dependency, just use `npm install <pkg>` / `npm uninstall <pkg>`.
+```bash
+npx skills add nudeps/nudeps
 ```
+
+The skill file is also available at `node_modules/nudeps/SKILL.md` after installation.
 
 ## How does it work?
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: nudeps
+description: Use when a project has nudeps in devDependencies or dependencies, has a nudeps.js config file, or has a package.json script that runs nudeps.
+---
+
+# nudeps — Bundler-Free Dependency Management
+
+Copies npm packages to a local output directory, generates an import map mapping bare specifiers to local versioned paths. No bundler, no build step. Output paths are configurable — check the nudeps config file (default `nudeps.js`, configurable via `--config`) or option defaults before assuming directory/file names.
+
+## Common Mistakes
+
+| Mistake                                                         | Fix                                                                                                                                                                                             |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Running `npx nudeps` after `npm install`/`npm uninstall`        | Check package.json `scripts` for any value containing `nudeps`. If a hook runs it → don't run manually. If no hook → run `npx nudeps` explicitly                                                |
+| `<script type="module" src="importmap.js">`                     | Must be a classic script: `<script src="importmap.js">`. Using `type="module"` dramatically reduces browser support                                                                             |
+| Editing files under the output directory or the import map file | These are generated artifacts owned by nudeps — changes get overwritten. Check the nudeps config or option defaults (`dir`, `map`) to know which paths are managed                              |
+| Importing a CJS package with `import`                           | nudeps reports which packages are CJS in its output. For those, use `import { require } from "cjs-browser-shim"` then `const pkg = require("pkg-name")`. If `cjs` option is disabled, enable it |
+| Using bare specifiers in Web Workers                            | Specifiers don't work in workers — this is a platform limitation, not a nudeps bug                                                                                                              |
+| Modifying the `dependencies`/`prepare` scripts in package.json  | These are npm lifecycle hooks installed by nudeps — don't edit or call them manually                                                                                                            |
+| Hardcoding `client_modules/` or `importmap.js` paths            | These are configurable defaults (`dir` and `map` options). Read the project's nudeps config to determine actual paths                                                                           |
+| Specifier fails to resolve at runtime                           | Ensure entry points are declared in package.json, then run `npx nudeps`. See Troubleshooting in README.md (in the nudeps package directory)                                                     |
+| Using an unsupported package manager                            | Only npm is officially supported. nudeps reads `node_modules/.package-lock.json` which other package managers may not produce                                                                   |
+
+## Lifecycle
+
+`npx nudeps install` (one-time setup) adds two npm hooks to package.json:
+
+- **`dependencies`** — fires after `npm install <pkg>` / `npm uninstall <pkg>`
+- **`prepare`** — fires on bare `npm install` (e.g., after cloning) and before `npm pack`/`npm publish`
+
+If these hooks exist, nudeps runs automatically — **do not run it manually**. If they don't exist, run `npx nudeps` explicitly after dependency changes.
+
+Use `npx nudeps --init` to force a full re-initialization (clears caches and regenerates everything).
+
+## Setup (New Projects)
+
+```bash
+npx nudeps install   # one-time: installs nudeps, adds hooks, sets type: "module", generates import map
+npm install <pkg>    # import map auto-updates via hooks (see Lifecycle above)
+```
+
+Include the import map **before any module scripts**, as a classic (non-module) script:
+
+```html
+<!-- path depends on the `map` option in nudeps config (default: importmap.js) -->
+<script src="importmap.js"></script>
+<script type="module" src="app.js"></script>
+```
+
+Then use bare specifiers in your modules:
+
+```js
+import { someFunction } from "some-package";
+```
+
+## Config (default: `nudeps.js`, configurable via `--config`)
+
+Config file uses ES module syntax: `export default { ... }`.
+
+| Option    | Default            | Description                                                                                                                                              |
+| --------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dir`     | `"client_modules"` | Output directory for copied packages                                                                                                                     |
+| `map`     | `"importmap.js"`   | Import map injection script path                                                                                                                         |
+| `mode`    | —                  | Preset: `"dev"` (symlink) or `"prod"` (prune + terse)                                                                                                    |
+| `exclude` | `[]`               | Packages to omit from import map (e.g., server-only deps)                                                                                                |
+| `cjs`     | `true`             | Include CJS shim for CommonJS packages                                                                                                                   |
+| `prune`   | `false`            | Subset import map to only used specifiers                                                                                                                |
+| `alias`   | `true`             | Unversioned symlinks for stable asset URLs (CSS, images). Use the unversioned path in HTML/CSS (e.g., `<link href="[output-dir]/open-props/style.css">`) |
+
+Full option reference and troubleshooting: see README.md in the nudeps package directory.
+
+## CJS Packages
+
+nudeps automatically detects CJS packages and logs a message like:
+
+> 2 CommonJS packages detected, adding cjs-browser-shim. Use require() to import these packages: react, react-dom. Disable with --cjs=false
+
+**Don't guess whether a package is CJS** — read nudeps' output after install. If you can't see the output (truncated, CI, etc.), check whether `cjs-browser-shim` appears in the generated import map file — if it does, CJS packages were detected.
+
+If the `cjs` option is `false` and you need CJS packages, set it to `true` in the nudeps config and run `npx nudeps`.
+
+For CJS packages, use the shim pattern:
+
+```js
+import { require } from "cjs-browser-shim";
+const { createElement } = require("react");
+```
+
+## Output
+
+nudeps logs a summary after each run: number of import map entries, time taken, and cache hits. If packages were copied or deleted, that's logged too. Warnings about CJS packages, missing lockfiles, or local dependencies appear inline — read them before proceeding.
+
+## Local Dependencies
+
+`npm install ../other-repo` works — nudeps symlinks local packages by default instead of copying. If the local dep doesn't have nudeps installed, a warning is printed — run `npx nudeps install` there too. When the local dependency's import map changes, nudeps automatically propagates to dependents.
+
+## Programmatic API
+
+For build scripts or CI pipelines that need nudeps as a step. Accepts the same options as the config file:
+
+```js
+import nudeps from "nudeps";
+await nudeps({ prune: true });
+```
+
+## Generated Artifacts — Do Not Edit
+
+- **Output directory** (`dir` option) — copied/symlinked packages
+- **Import map file** (`map` option) — auto-generated injection script
+- **`.nudeps/`** — cache directory
+
+All three contain `.gitignore` files preventing accidental commits. Add top-level ignores (using actual configured `dir` and `map` values) to hide them from your IDE.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
 		"nudeps": "src/cli/index.js"
 	},
 	"files": [
-		"src"
+		"src",
+		"SKILL.md"
 	],
 	"scripts": {
 		"release": "npm login && release-it",


### PR DESCRIPTION
Teaches AI coding agents the nudeps workflow: lifecycle hooks, generated artifacts, CJS handling, configurable paths, and common mistakes. Ships with the npm package.

### Changes

- `SKILL.md`: new agent skill reference
- `README.md`: replace inline AI instructions with pointer to `SKILL.md`
- `CLAUDE.md`: remind to keep `SKILL.md` in sync with code changes
- `package.json`: include SKILL.md in published files