### PR TITLE
Add npm workspace support with lockfile path rebasing

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -96,7 +96,7 @@ nudeps logs a summary after each run: number of import map entries, time taken, 
 
 ## npm Workspaces
 
-Running nudeps inside a workspace package works: it finds the lockfile at the monorepo root (deps are hoisted there), so hoisted dependencies and sibling workspace packages both resolve and get copied into the package's output dir. Limitations: change propagation between sibling workspace packages is not wired up, and hoisted deps aren't cached between runs.
+Running nudeps inside a workspace package works: it finds the lockfile at the monorepo root (deps are hoisted there), so hoisted dependencies and sibling workspace packages both resolve and get copied into the package's output dir. Limitation: change propagation between sibling workspace packages is not wired up.
 
 ## Programmatic API
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -96,7 +96,7 @@ nudeps logs a summary after each run: number of import map entries, time taken, 
 
 ## npm Workspaces
 
-Running nudeps inside a workspace package works: it finds the lockfile at the monorepo root (deps are hoisted there), so hoisted dependencies and sibling workspace packages both resolve and get copied into the package's output dir. Limitation: change propagation between sibling workspace packages is not wired up.
+Running nudeps inside a workspace package works: it finds the lockfile at the monorepo root (deps are hoisted there), so hoisted dependencies and sibling workspace packages both resolve — hoisted deps get copied, siblings get symlinked into the package's output dir. Limitation: change propagation between sibling workspace packages is not wired up.
 
 ## Programmatic API
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -94,6 +94,10 @@ nudeps logs a summary after each run: number of import map entries, time taken, 
 
 `npm install ../other-repo` works — nudeps symlinks local packages by default instead of copying. If the local dep doesn't have nudeps installed, a warning is printed — run `npx nudeps install` there too. When the local dependency's import map changes, nudeps automatically propagates to dependents.
 
+## npm Workspaces
+
+Running nudeps inside a workspace package works: it finds the lockfile at the monorepo root (deps are hoisted there), so hoisted dependencies and sibling workspace packages both resolve and get copied into the package's output dir. Limitations: change propagation between sibling workspace packages is not wired up, and hoisted deps aren't cached between runs.
+
 ## Programmatic API
 
 For build scripts or CI pipelines that need nudeps as a step. Accepts the same options as the config file:

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,20 @@ import { writeJSONSync, createGitignoredDir } from "./util.js";
 import Nudeps from "./nudeps.js";
 
 export default async function (options) {
+	// A workspace child's install-time hooks (e.g. `prepare`) run before npm writes the lockfile —
+	// skip that too-early run; the post-install re-run (lockfile now present) regenerates.
+	let root = process.env.npm_config_local_prefix;
+	if (
+		root &&
+		root !== process.cwd() &&
+		!existsSync(path.join(root, "node_modules", ".package-lock.json"))
+	) {
+		console.info(
+			"[nudeps] Skipping import map generation during workspace install — it runs once the lockfile is written. If this is not a workspace, please run Nudeps from the package root.",
+		);
+		return;
+	}
+
 	let config = await getConfig(options);
 	let nudeps = new Nudeps({ config });
 	let oldConfig = nudeps.oldConfig;

--- a/src/map.js
+++ b/src/map.js
@@ -70,7 +70,7 @@ export class ImportMapGenerator extends Generator {
 	async install (alias, target, { noRetry, ...installOptions } = {}) {
 		if (target === undefined) {
 			// Locate the dep in node_modules — at the monorepo root (prefix) under workspaces.
-			let prefix = this.nudeps?.modules.prefix ?? "";
+			let prefix = this.nudeps?.packages.prefix ?? "";
 			target = `${prefix ? prefix + "/" : "./"}node_modules/${alias}`;
 		}
 

--- a/src/map.js
+++ b/src/map.js
@@ -2,6 +2,7 @@
  * Utils for generating and manipulating import maps
  */
 import { Generator } from "@jspm/generator";
+import { existsSync } from "node:fs";
 
 import { deepAssign, getNodeBuiltins } from "./util.js";
 import { findOverride } from "./util/jspm-overrides.js";
@@ -67,7 +68,17 @@ export class ImportMapGenerator extends Generator {
 		return this.traceMap.resolver.pm;
 	}
 
-	async install (alias, target = `./node_modules/${alias}`, { noRetry, ...installOptions } = {}) {
+	async install (alias, target, { noRetry, ...installOptions } = {}) {
+		if (target === undefined) {
+			// Default to the package's local node_modules copy. If it isn't there —
+			// e.g. deps hoisted to a monorepo root under npm workspaces — fall back to
+			// bare-name resolution so the nodemodules provider walks up the tree to find
+			// it. (Pinning a non-existent ./node_modules/<name> path crashes subpath
+			// tracing.) Bare targets aren't parsed to a package, so they skip the cache.
+			let local = `./node_modules/${alias}`;
+			target = existsSync(local) ? local : alias;
+		}
+
 		// Check if this install is cacheable:
 		// must have a cache, not be the root package ("."), and not be a symlink (local dep)
 		let pkg = this.nudeps && target !== "." ? this.nudeps.packages.parse(target).pkg : null;

--- a/src/map.js
+++ b/src/map.js
@@ -70,11 +70,9 @@ export class ImportMapGenerator extends Generator {
 
 	async install (alias, target, { noRetry, ...installOptions } = {}) {
 		if (target === undefined) {
-			// Default to the package's local node_modules copy. If it isn't there —
-			// e.g. deps hoisted to a monorepo root under npm workspaces — fall back to
-			// bare-name resolution so the nodemodules provider walks up the tree to find
-			// it. (Pinning a non-existent ./node_modules/<name> path crashes subpath
-			// tracing.) Bare targets aren't parsed to a package, so they skip the cache.
+			// Default to the local copy, but fall back to bare-name resolution when it's
+			// missing (deps hoisted to a workspace root): a non-existent target crashes
+			// subpath tracing, whereas a bare name lets the provider walk up to find it.
 			let local = `./node_modules/${alias}`;
 			target = existsSync(local) ? local : alias;
 		}

--- a/src/map.js
+++ b/src/map.js
@@ -2,7 +2,6 @@
  * Utils for generating and manipulating import maps
  */
 import { Generator } from "@jspm/generator";
-import { existsSync } from "node:fs";
 
 import { deepAssign, getNodeBuiltins } from "./util.js";
 import { findOverride } from "./util/jspm-overrides.js";
@@ -70,11 +69,9 @@ export class ImportMapGenerator extends Generator {
 
 	async install (alias, target, { noRetry, ...installOptions } = {}) {
 		if (target === undefined) {
-			// Default to the local copy, but fall back to bare-name resolution when it's
-			// missing (deps hoisted to a workspace root): a non-existent target crashes
-			// subpath tracing, whereas a bare name lets the provider walk up to find it.
-			let local = `./node_modules/${alias}`;
-			target = existsSync(local) ? local : alias;
+			// Locate the dep in node_modules — at the monorepo root (prefix) under workspaces.
+			let prefix = this.nudeps?.modules.prefix ?? "";
+			target = `${prefix ? prefix + "/" : "./"}node_modules/${alias}`;
 		}
 
 		// Check if this install is cacheable:

--- a/src/nudeps.js
+++ b/src/nudeps.js
@@ -10,7 +10,7 @@ import Hooks from "blissful-hooks";
 
 import { readJSONSync, writeJSONSync, createGitignoredDir } from "./util.js";
 import { ImportMapGenerator, ImportMap } from "./map.js";
-import { matchesGlob, ensureSymlink } from "./util/fs.js";
+import { matchesGlob, ensureSymlink, findLockfileDir } from "./util/fs.js";
 import { getTopLevelModules } from "./util.js";
 import Packages from "./util/packages.js";
 
@@ -177,24 +177,42 @@ export default class Nudeps {
 	}
 
 	get packages () {
-		if (!existsSync("node_modules") && existsSync("package.json")) {
-			throw new Error("node_modules not found. Run `npm install` first.");
+		// Find the lockfile, walking up for npm workspaces (where it lives at the
+		// monorepo root, not in the individual workspace package directory).
+		let lockDir = findLockfileDir(process.cwd());
+		if (lockDir === null) {
+			if (existsSync("package.json")) {
+				throw new Error("node_modules not found. Run `npm install` first.");
+			}
+			lockDir = process.cwd();
 		}
 
-		let data = readJSONSync("node_modules/.package-lock.json");
+		// In a workspace, the lockfile lives above cwd; linked entries are then
+		// workspace siblings whose deps are hoisted (no own node_modules), so the
+		// "run npm install there" warnings below don't apply.
+		let inWorkspace = lockDir !== process.cwd();
+		let prefix = inWorkspace ? path.relative(process.cwd(), lockDir) : "";
+
+		let data = readJSONSync(path.join(lockDir, "node_modules/.package-lock.json"));
 		let raw = data?.packages ?? {};
 
-		// Pre-load child lockfiles for external (linked) deps
+		// Pre-load child lockfiles for external (linked) deps. Lockfile `resolved`
+		// paths are relative to lockDir, which may differ from cwd in a workspace.
 		let children = {};
 		for (let [key, info] of Object.entries(raw)) {
 			if (info.link) {
-				let childData = readJSONSync(`${info.resolved}/node_modules/.package-lock.json`, {
-					optional: true,
-				});
+				let resolvedDir = path.resolve(lockDir, info.resolved);
+				let childData = readJSONSync(
+					path.join(resolvedDir, "node_modules/.package-lock.json"),
+					{ optional: true },
+				);
 				if (childData) {
 					children[info.resolved] = childData;
 				}
-				else if (!existsSync(`${info.resolved}/node_modules`)) {
+				else if (inWorkspace) {
+					// Workspace sibling with hoisted deps — nothing to pre-load.
+				}
+				else if (!existsSync(path.join(resolvedDir, "node_modules"))) {
 					this.info(
 						`Warning: node_modules not found at ${info.resolved}. Run \`npm install\` there first.`,
 					);
@@ -205,7 +223,7 @@ export default class Nudeps {
 			}
 		}
 
-		let value = new Packages(data, { children });
+		let value = new Packages(data, { children, prefix });
 		Object.defineProperty(this, "packages", { value, configurable: true });
 		return value;
 	}

--- a/src/nudeps.js
+++ b/src/nudeps.js
@@ -10,7 +10,7 @@ import Hooks from "blissful-hooks";
 
 import { readJSONSync, writeJSONSync, createGitignoredDir } from "./util.js";
 import { ImportMapGenerator, ImportMap } from "./map.js";
-import { matchesGlob, ensureSymlink, findLockfileDir } from "./util/fs.js";
+import { matchesGlob, ensureSymlink } from "./util/fs.js";
 import { getTopLevelModules } from "./util.js";
 import Packages from "./util/packages.js";
 
@@ -176,28 +176,45 @@ export default class Nudeps {
 		return value;
 	}
 
+	/**
+	 * Directory whose node_modules holds the installed deps and lockfile — cwd, or the
+	 * monorepo root when run inside a workspace package. `prefix` is the cwd→dir path
+	 * (e.g. "../.."), used to locate hoisted deps and rebase lockfile paths. Cached.
+	 */
+	get modules () {
+		let dir = process.cwd();
+		while (!existsSync(path.join(dir, "node_modules", ".package-lock.json"))) {
+			let parent = path.dirname(dir);
+			if (parent === dir) {
+				dir = null;
+				break;
+			}
+			dir = parent;
+		}
+
+		let prefix = dir && dir !== process.cwd() ? path.relative(process.cwd(), dir) : "";
+		let value = { dir, prefix };
+		Object.defineProperty(this, "modules", { value, configurable: true });
+		return value;
+	}
+
 	get packages () {
-		// Walk up for the lockfile, which in a workspace lives at the monorepo root.
-		let lockDir = findLockfileDir(process.cwd());
-		if (lockDir === null) {
+		let { dir, prefix } = this.modules;
+		if (dir === null) {
 			if (existsSync("package.json")) {
 				throw new Error("node_modules not found. Run `npm install` first.");
 			}
-			lockDir = process.cwd();
+			dir = process.cwd();
 		}
 
-		// prefix rebases the root-relative lockfile paths to cwd when run in a subdir.
-		let inWorkspace = lockDir !== process.cwd();
-		let prefix = inWorkspace ? path.relative(process.cwd(), lockDir) : "";
-
-		let data = readJSONSync(path.join(lockDir, "node_modules/.package-lock.json"));
+		let data = readJSONSync(path.join(dir, "node_modules/.package-lock.json"));
 		let raw = data?.packages ?? {};
 
-		// Pre-load child lockfiles for external (linked) deps; `resolved` is relative to lockDir.
+		// Pre-load child lockfiles for external (linked) deps; `resolved` is relative to dir.
 		let children = {};
 		for (let [key, info] of Object.entries(raw)) {
 			if (info.link) {
-				let resolvedDir = path.resolve(lockDir, info.resolved);
+				let resolvedDir = path.resolve(dir, info.resolved);
 				let childData = readJSONSync(
 					path.join(resolvedDir, "node_modules/.package-lock.json"),
 					{ optional: true },
@@ -205,7 +222,7 @@ export default class Nudeps {
 				if (childData) {
 					children[info.resolved] = childData;
 				}
-				else if (inWorkspace) {
+				else if (prefix) {
 					// Workspace siblings hoist their deps — nothing to pre-load.
 				}
 				else if (!existsSync(path.join(resolvedDir, "node_modules"))) {

--- a/src/nudeps.js
+++ b/src/nudeps.js
@@ -177,8 +177,7 @@ export default class Nudeps {
 	}
 
 	get packages () {
-		// Find the lockfile, walking up for npm workspaces (where it lives at the
-		// monorepo root, not in the individual workspace package directory).
+		// Walk up for the lockfile, which in a workspace lives at the monorepo root.
 		let lockDir = findLockfileDir(process.cwd());
 		if (lockDir === null) {
 			if (existsSync("package.json")) {
@@ -187,17 +186,14 @@ export default class Nudeps {
 			lockDir = process.cwd();
 		}
 
-		// In a workspace, the lockfile lives above cwd; linked entries are then
-		// workspace siblings whose deps are hoisted (no own node_modules), so the
-		// "run npm install there" warnings below don't apply.
+		// prefix rebases the root-relative lockfile paths to cwd when run in a subdir.
 		let inWorkspace = lockDir !== process.cwd();
 		let prefix = inWorkspace ? path.relative(process.cwd(), lockDir) : "";
 
 		let data = readJSONSync(path.join(lockDir, "node_modules/.package-lock.json"));
 		let raw = data?.packages ?? {};
 
-		// Pre-load child lockfiles for external (linked) deps. Lockfile `resolved`
-		// paths are relative to lockDir, which may differ from cwd in a workspace.
+		// Pre-load child lockfiles for external (linked) deps; `resolved` is relative to lockDir.
 		let children = {};
 		for (let [key, info] of Object.entries(raw)) {
 			if (info.link) {
@@ -210,7 +206,7 @@ export default class Nudeps {
 					children[info.resolved] = childData;
 				}
 				else if (inWorkspace) {
-					// Workspace sibling with hoisted deps — nothing to pre-load.
+					// Workspace siblings hoist their deps — nothing to pre-load.
 				}
 				else if (!existsSync(path.join(resolvedDir, "node_modules"))) {
 					this.info(

--- a/src/nudeps.js
+++ b/src/nudeps.js
@@ -176,67 +176,8 @@ export default class Nudeps {
 		return value;
 	}
 
-	/**
-	 * Directory whose node_modules holds the installed deps and lockfile — cwd, or the
-	 * monorepo root when run inside a workspace package. `prefix` is the cwd→dir path
-	 * (e.g. "../.."), used to locate hoisted deps and rebase lockfile paths. Cached.
-	 */
-	get modules () {
-		let dir = process.cwd();
-		while (!existsSync(path.join(dir, "node_modules", ".package-lock.json"))) {
-			let parent = path.dirname(dir);
-			if (parent === dir) {
-				dir = null;
-				break;
-			}
-			dir = parent;
-		}
-
-		let prefix = dir && dir !== process.cwd() ? path.relative(process.cwd(), dir) : "";
-		let value = { dir, prefix };
-		Object.defineProperty(this, "modules", { value, configurable: true });
-		return value;
-	}
-
 	get packages () {
-		let { dir, prefix } = this.modules;
-		if (dir === null) {
-			if (existsSync("package.json")) {
-				throw new Error("node_modules not found. Run `npm install` first.");
-			}
-			dir = process.cwd();
-		}
-
-		let data = readJSONSync(path.join(dir, "node_modules/.package-lock.json"));
-		let raw = data?.packages ?? {};
-
-		// Pre-load child lockfiles for external (linked) deps; `resolved` is relative to dir.
-		let children = {};
-		for (let [key, info] of Object.entries(raw)) {
-			if (info.link) {
-				let resolvedDir = path.resolve(dir, info.resolved);
-				let childData = readJSONSync(
-					path.join(resolvedDir, "node_modules/.package-lock.json"),
-					{ optional: true },
-				);
-				if (childData) {
-					children[info.resolved] = childData;
-				}
-				else if (prefix) {
-					// Workspace siblings hoist their deps — nothing to pre-load.
-				}
-				else if (!existsSync(path.join(resolvedDir, "node_modules"))) {
-					this.info(
-						`Warning: node_modules not found at ${info.resolved}. Run \`npm install\` there first.`,
-					);
-				}
-				else {
-					this.info(`Warning: No lockfile found at ${info.resolved}`);
-				}
-			}
-		}
-
-		let value = new Packages(data, { children, prefix });
+		let value = Packages.load(process.cwd(), { warn: msg => this.info(msg) });
 		Object.defineProperty(this, "packages", { value, configurable: true });
 		return value;
 	}

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -127,6 +127,35 @@ export function createGitignoredDir (dir) {
 }
 
 /**
+ * Walk up from `startDir` to find the nearest directory containing
+ * node_modules/.package-lock.json (npm's hidden lockfile).
+ *
+ * This enables running nudeps inside an npm workspace package: under default
+ * hoisting, individual workspace packages have no node_modules/.package-lock.json
+ * of their own — the only one lives at the monorepo root. The generator already
+ * resolves hoisted deps and linked siblings via standard upward node resolution,
+ * so reading the root lockfile is enough for nudeps to map and copy them.
+ * @param {string} startDir
+ * @returns {string|null} Directory containing node_modules/.package-lock.json, or null if none up to the filesystem root.
+ */
+export function findLockfileDir (startDir) {
+	let dir = path.resolve(startDir);
+
+	while (true) {
+		if (existsSync(path.join(dir, "node_modules", ".package-lock.json"))) {
+			return dir;
+		}
+
+		let parent = path.dirname(dir);
+		if (parent === dir) {
+			return null;
+		}
+
+		dir = parent;
+	}
+}
+
+/**
  * Create a symlink, optionally replacing an existing one.
  * With `force`, removes any existing entry at `linkPath` before creating.
  * @param {string} target - The symlink target (what it points to)

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -127,29 +127,6 @@ export function createGitignoredDir (dir) {
 }
 
 /**
- * Walk up from `startDir` to the nearest directory with node_modules/.package-lock.json.
- * Lets nudeps run inside an npm workspace package, where the only lockfile is at the root.
- * @param {string} startDir
- * @returns {string|null} The directory, or null if none up to the filesystem root.
- */
-export function findLockfileDir (startDir) {
-	let dir = path.resolve(startDir);
-
-	while (true) {
-		if (existsSync(path.join(dir, "node_modules", ".package-lock.json"))) {
-			return dir;
-		}
-
-		let parent = path.dirname(dir);
-		if (parent === dir) {
-			return null;
-		}
-
-		dir = parent;
-	}
-}
-
-/**
  * Create a symlink, optionally replacing an existing one.
  * With `force`, removes any existing entry at `linkPath` before creating.
  * @param {string} target - The symlink target (what it points to)

--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -127,16 +127,10 @@ export function createGitignoredDir (dir) {
 }
 
 /**
- * Walk up from `startDir` to find the nearest directory containing
- * node_modules/.package-lock.json (npm's hidden lockfile).
- *
- * This enables running nudeps inside an npm workspace package: under default
- * hoisting, individual workspace packages have no node_modules/.package-lock.json
- * of their own — the only one lives at the monorepo root. The generator already
- * resolves hoisted deps and linked siblings via standard upward node resolution,
- * so reading the root lockfile is enough for nudeps to map and copy them.
+ * Walk up from `startDir` to the nearest directory with node_modules/.package-lock.json.
+ * Lets nudeps run inside an npm workspace package, where the only lockfile is at the root.
  * @param {string} startDir
- * @returns {string|null} Directory containing node_modules/.package-lock.json, or null if none up to the filesystem root.
+ * @returns {string|null} The directory, or null if none up to the filesystem root.
  */
 export function findLockfileDir (startDir) {
 	let dir = path.resolve(startDir);

--- a/src/util/packages.js
+++ b/src/util/packages.js
@@ -16,9 +16,14 @@ export default class Packages {
 	 * @param {object} data - Lockfile data (npm's .package-lock.json format)
 	 * @param {object} [options]
 	 * @param {object} [options.children] - Child lockfile data keyed by resolved path, for merging transitive deps of local deps
+	 * @param {string} [options.prefix] - Path from cwd to the lockfile's directory (e.g. "../.." when run inside an npm workspace package). Lockfile paths are relative to that directory; this rebases them to be cwd-relative. Keys (used for URL matching) stay as-is.
 	 */
-	constructor (data, { children = {} } = {}) {
+	constructor (data, { children = {}, prefix = "" } = {}) {
 		let raw = data?.packages ?? {};
+
+		// Rebase a lockfile-relative path to cwd. Without a prefix this preserves the
+		// historical "./"-prefixed form; with one (workspace mode) it prepends e.g. "../..".
+		let rebase = p => (prefix ? prefix + "/" + p : "./" + p);
 
 		for (let [key, info] of Object.entries(raw).filter(([key, info]) => key)) {
 			if (!key) {
@@ -32,8 +37,12 @@ export default class Packages {
 				installName,
 				name: resolved?.name,
 				version: resolved?.version,
-				path: "./" + key,
-				resolvedPath: info.link ? info.resolved : undefined,
+				path: rebase(key),
+				resolvedPath: info.link
+					? prefix
+						? prefix + "/" + info.resolved
+						: info.resolved
+					: undefined,
 				info: resolved,
 			});
 		}

--- a/src/util/packages.js
+++ b/src/util/packages.js
@@ -1,4 +1,8 @@
+import { existsSync } from "node:fs";
+import * as path from "node:path";
+
 import Package from "./package.js";
+import { readJSONSync } from "./fs.js";
 
 export { Package };
 
@@ -13,12 +17,78 @@ export default class Packages {
 	#parseCache = {};
 
 	/**
+	 * Locate and read npm's lockfile(s) from disk, then build a Packages.
+	 * Walks up from `cwd` to the nearest node_modules/.package-lock.json — which in an
+	 * npm workspace lives at the monorepo root — and rebases paths to cwd accordingly.
+	 * @param {string} [cwd]
+	 * @param {object} [options]
+	 * @param {(message: string) => void} [options.warn] - Called for non-fatal lockfile issues.
+	 * @returns {Packages}
+	 */
+	static load (cwd = process.cwd(), { warn = () => {} } = {}) {
+		let dir = cwd;
+		while (!existsSync(path.join(dir, "node_modules", ".package-lock.json"))) {
+			let parent = path.dirname(dir);
+			if (parent === dir) {
+				dir = null;
+				break;
+			}
+			dir = parent;
+		}
+
+		if (dir === null) {
+			if (existsSync(path.join(cwd, "package.json"))) {
+				throw new Error("node_modules not found. Run `npm install` first.");
+			}
+			dir = cwd;
+		}
+
+		let prefix = dir !== cwd ? path.relative(cwd, dir) : "";
+		let data = readJSONSync(path.join(dir, "node_modules/.package-lock.json"));
+		let raw = data?.packages ?? {};
+
+		// Pre-load child lockfiles for external (linked) deps; `resolved` is relative to dir.
+		let children = {};
+		for (let info of Object.values(raw)) {
+			if (!info.link) {
+				continue;
+			}
+
+			let resolvedDir = path.resolve(dir, info.resolved);
+			let childData = readJSONSync(
+				path.join(resolvedDir, "node_modules/.package-lock.json"),
+				{
+					optional: true,
+				},
+			);
+
+			if (childData) {
+				children[info.resolved] = childData;
+			}
+			else if (prefix) {
+				// Workspace siblings hoist their deps — nothing to pre-load.
+			}
+			else if (!existsSync(path.join(resolvedDir, "node_modules"))) {
+				warn(
+					`Warning: node_modules not found at ${info.resolved}. Run \`npm install\` there first.`,
+				);
+			}
+			else {
+				warn(`Warning: No lockfile found at ${info.resolved}`);
+			}
+		}
+
+		return new Packages(data, { children, prefix });
+	}
+
+	/**
 	 * @param {object} data - Lockfile data (npm's .package-lock.json format)
 	 * @param {object} [options]
 	 * @param {object} [options.children] - Child lockfile data keyed by resolved path, for merging transitive deps of local deps
 	 * @param {string} [options.prefix] - cwd→lockfile-dir path (e.g. "../..") for workspaces, to rebase paths to cwd. Keys stay as-is for URL matching.
 	 */
 	constructor (data, { children = {}, prefix = "" } = {}) {
+		this.prefix = prefix;
 		let raw = data?.packages ?? {};
 
 		// Rebase a lockfile-relative path to cwd (no prefix keeps the historical "./" form).

--- a/src/util/packages.js
+++ b/src/util/packages.js
@@ -44,7 +44,9 @@ export default class Packages {
 		}
 
 		let prefix = dir !== cwd ? path.relative(cwd, dir) : "";
-		let data = readJSONSync(path.join(dir, "node_modules/.package-lock.json"));
+		let data = readJSONSync(path.join(dir, "node_modules/.package-lock.json"), {
+			optional: true,
+		});
 		let raw = data?.packages ?? {};
 
 		// Pre-load child lockfiles for external (linked) deps; `resolved` is relative to dir.
@@ -63,7 +65,7 @@ export default class Packages {
 			);
 
 			if (childData) {
-				children[info.resolved] = childData;
+				children[prefix ? prefix + "/" + info.resolved : info.resolved] = childData;
 			}
 			else if (prefix) {
 				// Workspace siblings hoist their deps — nothing to pre-load.
@@ -109,7 +111,7 @@ export default class Packages {
 				path: rebase(key),
 				resolvedPath: info.link
 					? prefix
-						? prefix + "/" + info.resolved
+						? rebase(info.resolved)
 						: info.resolved
 					: undefined,
 				info: resolved,

--- a/src/util/packages.js
+++ b/src/util/packages.js
@@ -16,13 +16,12 @@ export default class Packages {
 	 * @param {object} data - Lockfile data (npm's .package-lock.json format)
 	 * @param {object} [options]
 	 * @param {object} [options.children] - Child lockfile data keyed by resolved path, for merging transitive deps of local deps
-	 * @param {string} [options.prefix] - Path from cwd to the lockfile's directory (e.g. "../.." when run inside an npm workspace package). Lockfile paths are relative to that directory; this rebases them to be cwd-relative. Keys (used for URL matching) stay as-is.
+	 * @param {string} [options.prefix] - cwd→lockfile-dir path (e.g. "../..") for workspaces, to rebase paths to cwd. Keys stay as-is for URL matching.
 	 */
 	constructor (data, { children = {}, prefix = "" } = {}) {
 		let raw = data?.packages ?? {};
 
-		// Rebase a lockfile-relative path to cwd. Without a prefix this preserves the
-		// historical "./"-prefixed form; with one (workspace mode) it prepends e.g. "../..".
+		// Rebase a lockfile-relative path to cwd (no prefix keeps the historical "./" form).
 		let rebase = p => (prefix ? prefix + "/" + p : "./" + p);
 
 		for (let [key, info] of Object.entries(raw).filter(([key, info]) => key)) {

--- a/test/util/packages.js
+++ b/test/util/packages.js
@@ -67,11 +67,8 @@ let caseBPackages = new Packages(
 	},
 );
 
-// Case C: npm workspaces. Shape captured from a real `npm install` of a workspace root:
-// each workspace package appears twice — once as a link entry under node_modules/, and
-// once as a real entry at its on-disk path — while regular deps are hoisted to the root
-// node_modules/ (here `leftpad`, a dependency of pkg-a). Pins down that workspace packages
-// resolve as external (linked) and hoisted deps resolve as ordinary, non-external packages.
+// Case C: npm workspace root lockfile (from a real `npm install`). Workspace packages appear
+// as a link entry plus a real on-disk entry; regular deps (leftpad) are hoisted to the root.
 let workspacePackages = new Packages({
 	packages: {
 		"node_modules/@demo/pkg-a": { link: true, resolved: "packages/pkg-a" },
@@ -86,10 +83,8 @@ let workspacePackages = new Packages({
 	},
 });
 
-// Case D: workspace run from inside a package (prefix set). The lockfile lives at the
-// monorepo root, two levels up, so paths are rebased to cwd ("../..") while keys — which
-// match the generator's "../../node_modules/..." URLs — stay as-is. Pins down that parse()
-// still finds packages and that path/resolvedPath/sourcePath become cwd-relative.
+// Case D: same lockfile read from inside a package (prefix "../.."), so paths rebase to cwd
+// while keys still match the generator's "../../node_modules/..." URLs.
 let workspacePrefixPackages = new Packages(
 	{
 		packages: {
@@ -310,9 +305,7 @@ export default {
 				{ arg: "sourcePath", expect: "./node_modules/leftpad" },
 			],
 		},
-		// Case D: run from inside a workspace package — generator emits "../../node_modules/..."
-		// URLs (deps live at the monorepo root). With prefix set, paths rebase to cwd while the
-		// package is still found and copied from the right place.
+		// Case D: parsing the generator's "../../node_modules/..." URLs under prefix.
 		{
 			name: "../../node_modules/leftpad/index.js",
 			packages: workspacePrefixPackages,

--- a/test/util/packages.js
+++ b/test/util/packages.js
@@ -100,6 +100,22 @@ let workspacePrefixPackages = new Packages(
 	{ prefix: "../.." },
 );
 
+// Case E: workspace prefix + external linked dep with children.
+let workspaceExternalPackages = new Packages(
+	{
+		packages: {
+			"node_modules/ext-pkg": { link: true, resolved: "../ext" },
+			"../ext": { version: "1.0.0", name: "ext-pkg", devDependencies: { nudeps: "latest" } },
+		},
+	},
+	{
+		prefix: "../..",
+		children: {
+			"../../../ext": { packages: { "node_modules/dep": { version: "2.0.0", name: "dep" } } },
+		},
+	},
+);
+
 let dir = "./client_modules";
 
 /**
@@ -330,6 +346,16 @@ export default {
 				{ arg: "resolvedPath", expect: "../../packages/pkg-a" },
 				{ arg: "sourcePath", expect: "../../node_modules/@demo/pkg-a" },
 				{ arg: "localDir", expect: "./client_modules/@demo/pkg-a@1.0.0" },
+			],
+		},
+		// Case E: transitive dep of external linked dep, with workspace prefix.
+		{
+			name: "../../../ext/node_modules/dep/index.js",
+			packages: workspaceExternalPackages,
+			description: "Transitive dep merged under prefix",
+			tests: [
+				{ arg: "name", expect: "dep" },
+				{ arg: "version", expect: "2.0.0" },
 			],
 		},
 	],

--- a/test/util/packages.js
+++ b/test/util/packages.js
@@ -14,35 +14,58 @@ let defaultData = {
 let defaultPackages = new Packages(defaultData);
 
 // Case A: transitive dep via local dep's resolved path (../vue → nudeps-demo-vue)
-let caseAPackages = new Packages({
-	packages: {
-		"node_modules/nudeps-demo-vue": { link: true, resolved: "../vue" },
-		"../vue": { version: "0.0.1", name: "nudeps-demo-vue", devDependencies: { nudeps: "latest" } },
+let caseAPackages = new Packages(
+	{
+		packages: {
+			"node_modules/nudeps-demo-vue": { link: true, resolved: "../vue" },
+			"../vue": {
+				version: "0.0.1",
+				name: "nudeps-demo-vue",
+				devDependencies: { nudeps: "latest" },
+			},
+		},
 	},
-}, {
-	children: { "../vue": { packages: { "node_modules/vue": { version: "3.5.26", name: "vue" } } } },
-});
+	{
+		children: {
+			"../vue": { packages: { "node_modules/vue": { version: "3.5.26", name: "vue" } } },
+		},
+	},
+);
 
 // Case A with reuse: main lockfile also has vue@3.5.26
-let caseAReusePackages = new Packages({
-	packages: {
-		"node_modules/nudeps-demo-vue": { link: true, resolved: "../vue" },
-		"../vue": { version: "0.0.1", name: "nudeps-demo-vue", devDependencies: { nudeps: "latest" } },
-		"node_modules/vue": { version: "3.5.26", name: "vue" },
+let caseAReusePackages = new Packages(
+	{
+		packages: {
+			"node_modules/nudeps-demo-vue": { link: true, resolved: "../vue" },
+			"../vue": {
+				version: "0.0.1",
+				name: "nudeps-demo-vue",
+				devDependencies: { nudeps: "latest" },
+			},
+			"node_modules/vue": { version: "3.5.26", name: "vue" },
+		},
 	},
-}, {
-	children: { "../vue": { packages: { "node_modules/vue": { version: "3.5.26", name: "vue" } } } },
-});
+	{
+		children: {
+			"../vue": { packages: { "node_modules/vue": { version: "3.5.26", name: "vue" } } },
+		},
+	},
+);
 
 // Case B: nested under an external (linked) package
-let caseBPackages = new Packages({
-	packages: {
-		"node_modules/ext-pkg": { link: true, resolved: "../ext" },
-		"../ext": { version: "1.0.0", name: "ext-pkg", devDependencies: { nudeps: "latest" } },
+let caseBPackages = new Packages(
+	{
+		packages: {
+			"node_modules/ext-pkg": { link: true, resolved: "../ext" },
+			"../ext": { version: "1.0.0", name: "ext-pkg", devDependencies: { nudeps: "latest" } },
+		},
 	},
-}, {
-	children: { "../ext": { packages: { "node_modules/dep": { version: "2.0.0", name: "dep" } } } },
-});
+	{
+		children: {
+			"../ext": { packages: { "node_modules/dep": { version: "2.0.0", name: "dep" } } },
+		},
+	},
+);
 
 // Case C: npm workspaces. Shape captured from a real `npm install` of a workspace root:
 // each workspace package appears twice — once as a link entry under node_modules/, and
@@ -63,6 +86,25 @@ let workspacePackages = new Packages({
 	},
 });
 
+// Case D: workspace run from inside a package (prefix set). The lockfile lives at the
+// monorepo root, two levels up, so paths are rebased to cwd ("../..") while keys — which
+// match the generator's "../../node_modules/..." URLs — stay as-is. Pins down that parse()
+// still finds packages and that path/resolvedPath/sourcePath become cwd-relative.
+let workspacePrefixPackages = new Packages(
+	{
+		packages: {
+			"node_modules/@demo/pkg-a": { link: true, resolved: "packages/pkg-a" },
+			"node_modules/leftpad": { version: "0.0.1", name: "leftpad" },
+			"packages/pkg-a": {
+				name: "@demo/pkg-a",
+				version: "1.0.0",
+				dependencies: { leftpad: "0.0.1" },
+			},
+		},
+	},
+	{ prefix: "../.." },
+);
+
 let dir = "./client_modules";
 
 /**
@@ -80,18 +122,34 @@ export default {
 		let { pkg, filePath, sourcePath } = packages.parse(url);
 
 		switch (prop) {
-			case "filePath": return filePath;
-			case "sourcePath": return sourcePath;
-			case "pkg": return pkg;
-			case "name": return pkg?.name;
-			case "version": return pkg?.version;
-			case "installName": return pkg?.installName;
-			case "isExternal": return pkg?.isExternal ?? false;
-			case "isNested": return !!pkg?.parent;
-			case "localDir": return localDir(pkg);
-			case "localPath": return [localDir(pkg), filePath].join("/");
-			case "dirName": return pkg?.dirName;
-			case "parentName": return pkg?.parent?.name;
+			case "filePath":
+				return filePath;
+			case "sourcePath":
+				return sourcePath;
+			case "path":
+				return pkg?.path;
+			case "resolvedPath":
+				return pkg?.resolvedPath;
+			case "pkg":
+				return pkg;
+			case "name":
+				return pkg?.name;
+			case "version":
+				return pkg?.version;
+			case "installName":
+				return pkg?.installName;
+			case "isExternal":
+				return pkg?.isExternal ?? false;
+			case "isNested":
+				return !!pkg?.parent;
+			case "localDir":
+				return localDir(pkg);
+			case "localPath":
+				return [localDir(pkg), filePath].join("/");
+			case "dirName":
+				return pkg?.dirName;
+			case "parentName":
+				return pkg?.parent?.name;
 		}
 	},
 	tests: [
@@ -208,9 +266,7 @@ export default {
 		{
 			name: "../vue/node_modules/vue/dist/vue.esm-bundler.js",
 			packages: caseAReusePackages,
-			tests: [
-				{ arg: "localDir", expect: "./client_modules/vue@3.5.26" },
-			],
+			tests: [{ arg: "localDir", expect: "./client_modules/vue@3.5.26" }],
 		},
 		// Case B: nested under external — flat top-level
 		{
@@ -252,6 +308,35 @@ export default {
 				{ arg: "isExternal", expect: false },
 				{ arg: "localDir", expect: "./client_modules/leftpad@0.0.1" },
 				{ arg: "sourcePath", expect: "./node_modules/leftpad" },
+			],
+		},
+		// Case D: run from inside a workspace package — generator emits "../../node_modules/..."
+		// URLs (deps live at the monorepo root). With prefix set, paths rebase to cwd while the
+		// package is still found and copied from the right place.
+		{
+			name: "../../node_modules/leftpad/index.js",
+			packages: workspacePrefixPackages,
+			description: "Hoisted dep resolved from inside a workspace package (prefix)",
+			tests: [
+				{ arg: "name", expect: "leftpad" },
+				{ arg: "version", expect: "0.0.1" },
+				{ arg: "isExternal", expect: false },
+				{ arg: "path", expect: "../../node_modules/leftpad" },
+				{ arg: "sourcePath", expect: "../../node_modules/leftpad" },
+				{ arg: "localDir", expect: "./client_modules/leftpad@0.0.1" },
+			],
+		},
+		{
+			name: "../../node_modules/@demo/pkg-a/index.js",
+			packages: workspacePrefixPackages,
+			description: "Sibling workspace package resolved from inside a package (prefix)",
+			tests: [
+				{ arg: "name", expect: "@demo/pkg-a" },
+				{ arg: "isExternal", expect: true },
+				{ arg: "path", expect: "../../node_modules/@demo/pkg-a" },
+				{ arg: "resolvedPath", expect: "../../packages/pkg-a" },
+				{ arg: "sourcePath", expect: "../../node_modules/@demo/pkg-a" },
+				{ arg: "localDir", expect: "./client_modules/@demo/pkg-a@1.0.0" },
 			],
 		},
 	],

--- a/test/util/packages.js
+++ b/test/util/packages.js
@@ -44,6 +44,25 @@ let caseBPackages = new Packages({
 	children: { "../ext": { packages: { "node_modules/dep": { version: "2.0.0", name: "dep" } } } },
 });
 
+// Case C: npm workspaces. Shape captured from a real `npm install` of a workspace root:
+// each workspace package appears twice — once as a link entry under node_modules/, and
+// once as a real entry at its on-disk path — while regular deps are hoisted to the root
+// node_modules/ (here `leftpad`, a dependency of pkg-a). Pins down that workspace packages
+// resolve as external (linked) and hoisted deps resolve as ordinary, non-external packages.
+let workspacePackages = new Packages({
+	packages: {
+		"node_modules/@demo/pkg-a": { link: true, resolved: "packages/pkg-a" },
+		"node_modules/@demo/pkg-b": { link: true, resolved: "packages/pkg-b" },
+		"node_modules/leftpad": { version: "0.0.1", name: "leftpad" },
+		"packages/pkg-a": {
+			name: "@demo/pkg-a",
+			version: "1.0.0",
+			dependencies: { "@demo/pkg-b": "1.0.0", leftpad: "0.0.1" },
+		},
+		"packages/pkg-b": { name: "@demo/pkg-b", version: "1.0.0" },
+	},
+});
+
 let dir = "./client_modules";
 
 /**
@@ -203,6 +222,36 @@ export default {
 				{ arg: "isExternal", expect: true },
 				{ arg: "localDir", expect: "./client_modules/dep@2.0.0" },
 				{ arg: "sourcePath", expect: "../ext/node_modules/dep" },
+			],
+		},
+		// Case C: npm workspace package — symlinked into the root node_modules.
+		// Resolves through the link to its on-disk entry and is treated as external/linked,
+		// just like a `npm install ../foo` local dep.
+		{
+			name: "./node_modules/@demo/pkg-a/index.js",
+			packages: workspacePackages,
+			description: "npm workspace package, linked into root node_modules",
+			tests: [
+				{ arg: "name", expect: "@demo/pkg-a" },
+				{ arg: "version", expect: "1.0.0" },
+				{ arg: "isExternal", expect: true },
+				{ arg: "localDir", expect: "./client_modules/@demo/pkg-a@1.0.0" },
+				{ arg: "sourcePath", expect: "./node_modules/@demo/pkg-a" },
+			],
+		},
+		// Case C: hoisted dependency of a workspace package — npm installs it at the root
+		// node_modules/ rather than under the workspace package, so it is an ordinary,
+		// non-external package as far as nudeps is concerned.
+		{
+			name: "./node_modules/leftpad/index.js",
+			packages: workspacePackages,
+			description: "Hoisted dependency of a workspace package",
+			tests: [
+				{ arg: "name", expect: "leftpad" },
+				{ arg: "version", expect: "0.0.1" },
+				{ arg: "isExternal", expect: false },
+				{ arg: "localDir", expect: "./client_modules/leftpad@0.0.1" },
+				{ arg: "sourcePath", expect: "./node_modules/leftpad" },
 			],
 		},
 	],


### PR DESCRIPTION
## Summary
This PR adds support for npm workspaces by implementing dynamic lockfile discovery and path rebasing. The `Packages` class now walks up the directory tree to find the monorepo root's lockfile and rebases all paths relative to the current working directory, enabling nudeps to work correctly when run from inside a workspace package.

## Key Changes

- **Lockfile Discovery**: Added `Packages.load()` static method that walks up from `cwd` to find `node_modules/.package-lock.json` at the monorepo root, with fallback to current directory if not found
- **Path Rebasing**: Introduced `prefix` option to `Packages` constructor to rebase lockfile-relative paths to the current working directory (e.g., `../../node_modules/...` when running from a workspace package)
- **Child Lockfile Loading**: Pre-loads lockfiles for external (linked) dependencies, with special handling for workspace siblings that hoist their dependencies
- **Nudeps Integration**: Refactored `Nudeps.packages` getter to use `Packages.load()` instead of inline lockfile reading logic
- **ImportMapGenerator Update**: Updated `install()` method to compute correct `node_modules` paths accounting for workspace prefix
- **Test Coverage**: Added comprehensive test cases for workspace scenarios:
  - Workspace packages symlinked into root `node_modules`
  - Hoisted dependencies of workspace packages
  - Path resolution from inside a workspace package with prefix rebasing
- **Documentation**: Updated `SKILL.md` with npm workspace usage information

## Implementation Details

- The `prefix` parameter stores the relative path from cwd to the lockfile directory (e.g., `"../.."` when running from a workspace package)
- Path rebasing applies to both `path` and `resolvedPath` properties while keeping lockfile keys unchanged for URL matching
- Workspace siblings are detected by the absence of a child lockfile (they hoist deps to the root)
- Non-fatal warnings are issued for missing lockfiles or `node_modules` directories via an optional `warn` callback

https://claude.ai/code/session_01W2vwbUVRp4sWVGK8spkeTy

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #111
- <kbd>&nbsp;1&nbsp;</kbd> #103 👈 
<!-- GitButler Footer Boundary Bottom -->