### PR TITLE
Fix workspace edge cases from #103 review

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -96,7 +96,7 @@ nudeps logs a summary after each run: number of import map entries, time taken, 
 
 ## npm Workspaces
 
-Running nudeps inside a workspace package works: it finds the lockfile at the monorepo root (deps are hoisted there), so hoisted dependencies and sibling workspace packages both resolve and get copied into the package's output dir. Limitation: change propagation between sibling workspace packages is not wired up.
+Running nudeps inside a workspace package works: it finds the lockfile at the monorepo root (deps are hoisted there), so hoisted dependencies and sibling workspace packages both resolve — hoisted deps get copied, siblings get symlinked into the package's output dir. Limitation: change propagation between sibling workspace packages is not wired up.
 
 ## Programmatic API
 

--- a/src/util/packages.js
+++ b/src/util/packages.js
@@ -44,7 +44,9 @@ export default class Packages {
 		}
 
 		let prefix = dir !== cwd ? path.relative(cwd, dir) : "";
-		let data = readJSONSync(path.join(dir, "node_modules/.package-lock.json"));
+		let data = readJSONSync(path.join(dir, "node_modules/.package-lock.json"), {
+			optional: true,
+		});
 		let raw = data?.packages ?? {};
 
 		// Pre-load child lockfiles for external (linked) deps; `resolved` is relative to dir.
@@ -63,7 +65,7 @@ export default class Packages {
 			);
 
 			if (childData) {
-				children[info.resolved] = childData;
+				children[prefix ? prefix + "/" + info.resolved : info.resolved] = childData;
 			}
 			else if (prefix) {
 				// Workspace siblings hoist their deps — nothing to pre-load.
@@ -109,7 +111,7 @@ export default class Packages {
 				path: rebase(key),
 				resolvedPath: info.link
 					? prefix
-						? prefix + "/" + info.resolved
+						? rebase(info.resolved)
 						: info.resolved
 					: undefined,
 				info: resolved,

--- a/test/util/packages.js
+++ b/test/util/packages.js
@@ -100,6 +100,22 @@ let workspacePrefixPackages = new Packages(
 	{ prefix: "../.." },
 );
 
+// Case E: workspace prefix + external linked dep with children.
+let workspaceExternalPackages = new Packages(
+	{
+		packages: {
+			"node_modules/ext-pkg": { link: true, resolved: "../ext" },
+			"../ext": { version: "1.0.0", name: "ext-pkg", devDependencies: { nudeps: "latest" } },
+		},
+	},
+	{
+		prefix: "../..",
+		children: {
+			"../../../ext": { packages: { "node_modules/dep": { version: "2.0.0", name: "dep" } } },
+		},
+	},
+);
+
 let dir = "./client_modules";
 
 /**
@@ -330,6 +346,16 @@ export default {
 				{ arg: "resolvedPath", expect: "../../packages/pkg-a" },
 				{ arg: "sourcePath", expect: "../../node_modules/@demo/pkg-a" },
 				{ arg: "localDir", expect: "./client_modules/@demo/pkg-a@1.0.0" },
+			],
+		},
+		// Case E: transitive dep of external linked dep, with workspace prefix.
+		{
+			name: "../../../ext/node_modules/dep/index.js",
+			packages: workspaceExternalPackages,
+			description: "Transitive dep merged under prefix",
+			tests: [
+				{ arg: "name", expect: "dep" },
+				{ arg: "version", expect: "2.0.0" },
 			],
 		},
 	],


### PR DESCRIPTION
- Key `children` by rebased path so merge matches `pkg.resolvedPath`
- Make `readJSONSync` optional for the no-lockfile fallback
- Reuse `rebase()` for `resolvedPath`
- Fix `SKILL.md`: workspace siblings are symlinked, not copied
- Add Case E test: prefix + children combined

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #105 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #103
<!-- GitButler Footer Boundary Bottom -->