### PR TITLE
Resolve deps nested through multiple levels of linked packages

### DIFF
--- a/src/nudeps.js
+++ b/src/nudeps.js
@@ -491,9 +491,17 @@ export default class Nudeps {
 		let { config, existingDirs, existingSymlinks, toCopy, toDelete, toDeleteIfEmpty, stats } =
 			this;
 
-		// Copy (or symlink) package directories
+		// Copy (or symlink) package directories. The same package can be reached via
+		// multiple link paths (e.g. a linked dep depended on by two other linked deps),
+		// yielding several sources for one destination dir — materialize each dest once.
+		let materialized = new Set();
 		for (let from in toCopy) {
 			let to = toCopy[from];
+			if (materialized.has(to)) {
+				continue;
+			}
+			materialized.add(to);
+
 			let { pkg } = this.packages.parse(from);
 
 			let exists = existingDirs.has(to);

--- a/src/util/packages.js
+++ b/src/util/packages.js
@@ -213,10 +213,24 @@ export default class Packages {
 
 		let parts = url.split("/");
 		let index = parts.indexOf("node_modules");
-		let base = index === -1 ? null : parts.slice(0, index).join("/") || ".";
 
 		if (index === -1) {
 			return (this.#parseCache[url] = { pkg: null, filePath: "", sourcePath: url });
+		}
+
+		// Re-express base relative to the lockfile dir so it matches #byKey's keys (URLs and
+		// pkg.path are cwd-relative). With a workspace prefix the cwd→root prefix maps to the
+		// lockfile root "." (root keys stay raw, e.g. "node_modules/foo"), while resolved
+		// external paths are kept as-is. Without a prefix, drop a leading "./" so a re-parsed
+		// sourcePath (pkg.path, which carries "./") still matches.
+		let base = parts.slice(0, index).join("/") || ".";
+		if (this.prefix) {
+			if (base === this.prefix) {
+				base = ".";
+			}
+		}
+		else {
+			base = base.replace(/^\.\//, "");
 		}
 
 		let rest = parts.slice(index);
@@ -240,34 +254,23 @@ export default class Packages {
 			return (this.#parseCache[url] = { pkg: null, filePath, sourcePath: url });
 		}
 
-		let key = packageNames.map(n => "node_modules/" + n).join("/");
-		let pkg = this.#byKey[key] ?? null;
-
-		// If not found directly, check if the path goes through an external dep.
-		// Case A: base is the external's resolved path (e.g., ../vue/node_modules/vue)
-		// Case B: first package is external (e.g., node_modules/ext-pkg/node_modules/dep)
-		let effectiveBase = base;
-		if (!pkg) {
-			let resolvedBase = base && base !== "." ? base : null;
-
-			if (!resolvedBase && packageNames.length > 1) {
-				let topPkg = this.#byKey["node_modules/" + packageNames[0]];
-				if (topPkg?.resolvedPath !== topPkg?.path) {
-					resolvedBase = topPkg.resolvedPath;
-					key = packageNames
-						.slice(1)
-						.map(n => "node_modules/" + n)
-						.join("/");
-				}
+		// Walk the package chain one segment at a time, following each linked dep's
+		// resolved target before resolving the next. JSPM emits symbolic node_modules
+		// paths, but npm records a linked package's subtree under its resolved location,
+		// so every intermediate link must be dereferenced — not just the first.
+		let pkg = null;
+		let cursor = base;
+		for (let name of packageNames) {
+			let key = (cursor === "." ? "" : cursor + "/") + "node_modules/" + name;
+			pkg = this.#byKey[key] ?? null;
+			if (!pkg) {
+				break;
 			}
-
-			if (resolvedBase) {
-				pkg = this.#byKey[resolvedBase + "/" + key] ?? null;
-				if (pkg) effectiveBase = resolvedBase;
-			}
+			// Descend into the link target for external deps, else the package's own dir.
+			cursor = pkg.resolvedPath !== pkg.path ? pkg.resolvedPath : key;
 		}
 
-		let sourcePath = (effectiveBase === "." ? "" : effectiveBase + "/") + key;
+		let sourcePath = pkg ? pkg.path : url;
 		if (!sourcePath.startsWith(".")) sourcePath = "./" + sourcePath;
 
 		return (this.#parseCache[url] = { pkg, filePath, sourcePath });

--- a/test/util/packages.js
+++ b/test/util/packages.js
@@ -116,6 +116,27 @@ let workspaceExternalPackages = new Packages(
 	},
 );
 
+// Chained links: two linked packages in series before a leaf dep.
+// Models: app (link) → core (nested link) → util (regular dep)
+// npm flattens intermediate links into the root lockfile with their resolved paths.
+let chainedLinksPackages = new Packages(
+	{
+		packages: {
+			"node_modules/app": { link: true, resolved: "../app" },
+			"../app": { version: "3.0.0", name: "app", dependencies: { "@ns/core": "^3" } },
+			"../app/node_modules/@ns/core": { link: true, resolved: "../core" },
+			"../core": { version: "3.0.0", name: "@ns/core", dependencies: { "util-lib": "^0.1" } },
+		},
+	},
+	{
+		children: {
+			"../core": {
+				packages: { "node_modules/util-lib": { version: "0.1.5", name: "util-lib" } },
+			},
+		},
+	},
+);
+
 let dir = "./client_modules";
 
 /**
@@ -356,6 +377,19 @@ export default {
 			tests: [
 				{ arg: "name", expect: "dep" },
 				{ arg: "version", expect: "2.0.0" },
+			],
+		},
+		// Chained links: dep nested 2 levels deep through two linked packages.
+		{
+			name: "./node_modules/app/node_modules/@ns/core/node_modules/util-lib/src/index.js",
+			description: "Chained links: dep nested 2 levels deep through two linked packages",
+			packages: chainedLinksPackages,
+			tests: [
+				{ arg: "version", expect: "0.1.5" },
+				{ arg: "name", expect: "util-lib" },
+				{ arg: "isExternal", expect: true },
+				{ arg: "localDir", expect: "./client_modules/util-lib@0.1.5" },
+				{ arg: "sourcePath", expect: "../core/node_modules/util-lib" },
 			],
 		},
 	],


### PR DESCRIPTION
## TL;DR

When your project uses linked packages (npm symlinks / `file:` deps) that themselves depend on more linked packages — **3 levels deep** — the generated import map dropped the version folder from the deepest entries, so they pointed at files that don't exist (e.g. `./client_modules/src/index.js` instead of `./client_modules/blissful-hooks@0.0.2/src/index.js`). This breaks the page. The fix follows the symlink chain all the way down instead of stopping after the first hop. Surfaced by `inspire-js/demo`; longstanding bug, not a regression.

---

## Problem

`nudeps` produced an import map with broken entries for repos that chain **linked (symlinked / `file:`) packages 2+ levels deep**. In `inspire-js/demo` (`inspirejs.org` → `@inspirejs/core` → `blissful-hooks`), the package directory was dropped entirely:

```jsonc
"blissful-hooks": "./client_modules/src/index.js"          // ❌ missing  blissful-hooks@0.0.2/
"@inspirejs/core": "./client_modules/inspire.mjs"          // ❌ missing  @inspirejs/core@3.0.0/  (in scope)
```

JSPM emits *symbolic* `node_modules` paths, but npm stores a linked package's subtree under its **resolved target**. `Packages.parse()` translated symbolic → physical but only dereferenced the **first** link in the chain, so anything nested under a *second* link missed the lookup and returned `pkg: null`, and `localizeMap()` fell back to a path with no package dir.

This is not a regression — it has been broken since the feature became testable (~0.2.2); only the *form* of the breakage changed across refactors. See #107 for the full diagnosis.

## Fix

- **`parse()`** — replace the single-shot external resolution with an iterative walk that follows each linked dep's resolved target before resolving the next segment. Unifies the old fast path + both fallback cases (net **−17 lines**). Also normalizes a leading `./` out of `base` so a re-parsed `sourcePath` matches the key index.
- **`copyPackages()`** — materialize each destination dir once. The same package reached via two link paths now correctly yields two sources for one dest; without dedup the second `symlinkSync` threw `EEXIST` (previously masked because the 2-level reference never resolved).

Resulting map:

```jsonc
"blissful-hooks": "./client_modules/blissful-hooks@0.0.2/src/index.js"   ✓
"@inspirejs/core": "./client_modules/@inspirejs/core@3.0.0/inspire.mjs"  ✓
```

## Verification

- ✅ Target repo (`inspire-js/demo`): every entry has a correct `name@version` dir; all referenced files resolve on disk; linked packages stay symlinked, `blissful-hooks` copied.
- ✅ Test suite: 67/67 pass.
- ✅ No regressions: A/B-tested all 13 demos with fresh caches — **byte-identical output to baseline** for every one.

## Known remaining gap

Fixes the case where npm flattens intermediate links (with `version` + `resolved`) into the consumer's own root lockfile. It does **not** yet fix chains whose intermediate links are known only via the `children` lockfile-merge, which creates version-less / `resolvedPath`-less stubs. Deferred as a separate, currently-untriggered concern — detailed in [a comment on #107](https://github.com/nudeps/nudeps/issues/107#issuecomment-4616466687).

Refs #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

