### PR TITLE
Skip import map generation during workspace install

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,20 @@ export default async function (options) {
 	let nudeps = new Nudeps({ config });
 	let oldConfig = nudeps.oldConfig;
 
+	// A workspace child's install-time hooks (e.g. `prepare`) run before npm writes the lockfile —
+	// skip that too-early run; the post-install re-run (lockfile now present) regenerates.
+	let root = process.env.npm_config_local_prefix;
+	if (
+		root &&
+		root !== process.cwd() &&
+		!existsSync(path.join(root, "node_modules", ".package-lock.json"))
+	) {
+		nudeps.info(
+			"Skipping import map generation during workspace install — it runs once the lockfile is written.",
+		);
+		return;
+	}
+
 	let cacheExists = existsSync(".nudeps");
 	if (cacheExists && config.init) {
 		// Note: this also clears local-dependents.json. Dependents will

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ export default async function (options) {
 		!existsSync(path.join(root, "node_modules", ".package-lock.json"))
 	) {
 		console.info(
-			"[nudeps] Skipping import map generation during workspace install — it runs once the lockfile is written.",
+			"[nudeps] Skipping import map generation during workspace install — it runs once the lockfile is written. If this is not a workspace, please run Nudeps from the package root.",
 		);
 		return;
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,6 @@ import { writeJSONSync, createGitignoredDir } from "./util.js";
 import Nudeps from "./nudeps.js";
 
 export default async function (options) {
-	let config = await getConfig(options);
-	let nudeps = new Nudeps({ config });
-	let oldConfig = nudeps.oldConfig;
-
 	// A workspace child's install-time hooks (e.g. `prepare`) run before npm writes the lockfile —
 	// skip that too-early run; the post-install re-run (lockfile now present) regenerates.
 	let root = process.env.npm_config_local_prefix;
@@ -21,11 +17,15 @@ export default async function (options) {
 		root !== process.cwd() &&
 		!existsSync(path.join(root, "node_modules", ".package-lock.json"))
 	) {
-		nudeps.info(
-			"Skipping import map generation during workspace install — it runs once the lockfile is written.",
+		console.info(
+			"[nudeps] Skipping import map generation during workspace install — it runs once the lockfile is written.",
 		);
 		return;
 	}
+
+	let config = await getConfig(options);
+	let nudeps = new Nudeps({ config });
+	let oldConfig = nudeps.oldConfig;
 
 	let cacheExists = existsSync(".nudeps");
 	if (cacheExists && config.init) {


### PR DESCRIPTION
A workspace child's install-time hooks run before npm writes `node_modules/.package-lock.json`, so nudeps would abort the install with "node_modules not found." Detect that case — `npm_config_local_prefix` differs from `cwd` and no lockfile yet — and skip; the post-install re-run regenerates the map once the lockfile exists.

Stacked on #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #111 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #103
<!-- GitButler Footer Boundary Bottom -->