### PR TITLE
Add workspace root hooks during install

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -96,7 +96,7 @@ nudeps logs a summary after each run: number of import map entries, time taken, 
 
 ## npm Workspaces
 
-Running nudeps inside a workspace package works: it finds the lockfile at the monorepo root (deps are hoisted there), so hoisted dependencies and sibling workspace packages both resolve — hoisted deps get copied, siblings get symlinked into the package's output dir. Limitation: change propagation between sibling workspace packages is not wired up.
+Running nudeps inside a workspace package works: it finds the lockfile at the monorepo root (deps are hoisted there), so hoisted dependencies and sibling workspace packages both resolve — hoisted deps get copied, siblings get symlinked into the package's output dir. `npx nudeps install` in a workspace child automatically adds `dependencies` and `prepare` hooks to the workspace root that delegate to children (`npm run <hook> --if-present --workspaces`), so `npm install` at the root triggers import map generation in each child. Limitation: change propagation between sibling workspace packages is not wired up.
 
 ## Programmatic API
 

--- a/src/install.js
+++ b/src/install.js
@@ -40,16 +40,21 @@ export default async function () {
 
 	writeJSONSync("package.json", pkg, 2);
 
-	// Handle workspaces
-	let root = process.env.npm_config_local_prefix;
-	if (root && root !== process.cwd()) {
-		let rootPkg = readJSONSync(path.join(root, "package.json"), { optional: true });
+	// Handle workspaces: walk up to find a parent with `workspaces`.
+	// Can't use npm_config_local_prefix — it's only set during npm lifecycle hooks, not `npx nudeps install`.
+	let dir = path.dirname(process.cwd());
+	while (dir !== path.dirname(dir)) {
+		let rootPkg = readJSONSync(path.join(dir, "package.json"), { optional: true });
+
 		if (rootPkg?.workspaces) {
 			// Add hooks that delegate to children, so `npm install` at the root re-triggers nudeps after the lockfile is written.
 			for (let hook of ["dependencies", "prepare"]) {
 				addHook(rootPkg, hook, `npm run ${hook} --if-present --workspaces`);
 			}
-			writeJSONSync(path.join(root, "package.json"), rootPkg);
+			writeJSONSync(path.join(dir, "package.json"), rootPkg);
+			break;
 		}
+
+		dir = path.dirname(dir);
 	}
 }

--- a/src/install.js
+++ b/src/install.js
@@ -42,6 +42,7 @@ export default async function () {
 
 	// Handle workspaces: walk up to find a parent with `workspaces`.
 	// Can't use npm_config_local_prefix — it's only set during npm lifecycle hooks, not `npx nudeps install`.
+	// TODO move to Packages.findRoot()
 	let dir = path.dirname(process.cwd());
 	while (dir !== path.dirname(dir)) {
 		let rootPkg = readJSONSync(path.join(dir, "package.json"), { optional: true });

--- a/src/install.js
+++ b/src/install.js
@@ -1,5 +1,6 @@
 import { readJSONSync, writeJSONSync } from "./util.js";
 import { execSync } from "node:child_process";
+import * as path from "node:path";
 
 /**
  * Add a command to an npm lifecycle hook, falling back to pre/post variants if the hook is already taken.
@@ -38,4 +39,17 @@ export default async function () {
 	addHook(pkg, "prepare", command);
 
 	writeJSONSync("package.json", pkg, 2);
+
+	// Handle workspaces
+	let root = process.env.npm_config_local_prefix;
+	if (root && root !== process.cwd()) {
+		let rootPkg = readJSONSync(path.join(root, "package.json"), { optional: true });
+		if (rootPkg?.workspaces) {
+			// Add hooks that delegate to children, so `npm install` at the root re-triggers nudeps after the lockfile is written.
+			for (let hook of ["dependencies", "prepare"]) {
+				addHook(rootPkg, hook, `npm run ${hook} --if-present --workspaces`);
+			}
+			writeJSONSync(path.join(root, "package.json"), rootPkg);
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- When `npx nudeps install` runs in a workspace child, automatically adds `dependencies` and `prepare` hooks to the workspace root that delegate to children (`npm run <hook> --if-present --workspaces`)
- This ensures `npm install` at the root triggers import map generation in each workspace child
- Uses directory walk (not `npm_config_local_prefix`) since the env var is only set during npm lifecycle hooks, not manual `npx` invocations

Depends on #111 for the skip logic that prevents nudeps from failing when children's hooks fire before the lockfile is written.

## Test plan
- [x] Run `npx nudeps install` in a workspace child — verify root `package.json` gets both hooks
- [x] Run again — verify idempotent (no duplicate hooks)
- [x] Run outside a workspace — verify no root modification
- [ ] Run `npm install` at workspace root — verify children's import maps regenerate (requires full stack: #103 + #111 + this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)