### PR TITLE
Extract Packages.findRoot() and use it in install

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -1,4 +1,5 @@
 import { readJSONSync, writeJSONSync } from "./util.js";
+import Packages from "./util/packages.js";
 import { execSync } from "node:child_process";
 import * as path from "node:path";
 
@@ -40,22 +41,17 @@ export default async function () {
 
 	writeJSONSync("package.json", pkg, 2);
 
-	// Handle workspaces: walk up to find a parent with `workspaces`.
-	// Can't use npm_config_local_prefix — it's only set during npm lifecycle hooks, not `npx nudeps install`.
-	// TODO move to Packages.findRoot()
-	let dir = path.dirname(process.cwd());
-	while (dir !== path.dirname(dir)) {
-		let rootPkg = readJSONSync(path.join(dir, "package.json"), { optional: true });
+	// Handle workspaces: if cwd's lockfile lives at a parent, that parent is the workspace root.
+	let root = Packages.findRoot();
+	if (root && root !== process.cwd()) {
+		let rootPkg = readJSONSync(path.join(root, "package.json"), { optional: true });
 
 		if (rootPkg?.workspaces) {
 			// Add hooks that delegate to children, so `npm install` at the root re-triggers nudeps after the lockfile is written.
 			for (let hook of ["dependencies", "prepare"]) {
 				addHook(rootPkg, hook, `npm run ${hook} --if-present --workspaces`);
 			}
-			writeJSONSync(path.join(dir, "package.json"), rootPkg);
-			break;
+			writeJSONSync(path.join(root, "package.json"), rootPkg);
 		}
-
-		dir = path.dirname(dir);
 	}
 }

--- a/src/util/packages.js
+++ b/src/util/packages.js
@@ -17,6 +17,24 @@ export default class Packages {
 	#parseCache = {};
 
 	/**
+	 * Find the nearest ancestor (or `cwd` itself) with `node_modules/.package-lock.json`.
+	 * In npm workspaces this is the monorepo root.
+	 * @param {string} [cwd]
+	 * @returns {string|null}
+	 */
+	static findRoot (cwd = process.cwd()) {
+		let dir = cwd;
+		while (!existsSync(path.join(dir, "node_modules", ".package-lock.json"))) {
+			let parent = path.dirname(dir);
+			if (parent === dir) {
+				return null;
+			}
+			dir = parent;
+		}
+		return dir;
+	}
+
+	/**
 	 * Locate and read npm's lockfile(s) from disk, then build a Packages.
 	 * Walks up from `cwd` to the nearest node_modules/.package-lock.json — which in an
 	 * npm workspace lives at the monorepo root — and rebases paths to cwd accordingly.
@@ -26,15 +44,7 @@ export default class Packages {
 	 * @returns {Packages}
 	 */
 	static load (cwd = process.cwd(), { warn = () => {} } = {}) {
-		let dir = cwd;
-		while (!existsSync(path.join(dir, "node_modules", ".package-lock.json"))) {
-			let parent = path.dirname(dir);
-			if (parent === dir) {
-				dir = null;
-				break;
-			}
-			dir = parent;
-		}
+		let dir = Packages.findRoot(cwd);
 
 		if (dir === null) {
 			if (existsSync(path.join(cwd, "package.json"))) {

--- a/src/util/packages.js
+++ b/src/util/packages.js
@@ -18,7 +18,8 @@ export default class Packages {
 
 	/**
 	 * Find the nearest ancestor (or `cwd` itself) with `node_modules/.package-lock.json`.
-	 * In npm workspaces this is the monorepo root.
+	 * In npm workspaces this is the monorepo root; npm never writes the hidden
+	 * lockfile inside workspace children, even those with their own `node_modules/`.
 	 * @param {string} [cwd]
 	 * @returns {string|null}
 	 */


### PR DESCRIPTION
## Summary
- Extract the lockfile-root walk from `Packages.load()` into `static findRoot(cwd)` — returns the nearest ancestor with `node_modules/.package-lock.json`, or `null`
- Use `findRoot()` in `install.js` instead of manually walking up for `workspaces` in `package.json` — skips the walk entirely for standalone projects

Leftover from https://github.com/nudeps/nudeps/pull/112.

## Test plan
- [x] 101/101 unit tests pass
- [x] All demos produce unchanged output
- [x] Verified workspace child: root gets delegating hooks
- [x] Verified standalone project: no spurious walk

🤖 Generated with [Claude Code](https://claude.com/claude-code)