### PR TITLE
Fix parse() for transitive deps of npm-linked packages without child lockfile

### DIFF
--- a/src/util/packages.js
+++ b/src/util/packages.js
@@ -285,7 +285,12 @@ export default class Packages {
 			let key = (cursor === "." ? "" : cursor + "/") + "node_modules/" + name;
 			pkg = this.#byKey[key] ?? null;
 			if (!pkg) {
-				break;
+				// Global installs don't produce a child lockfile; try hoisted root
+				key = "node_modules/" + name;
+				pkg = this.#byKey[key] ?? null;
+				if (!pkg) {
+					break;
+				}
 			}
 			// Descend into the link target for external deps, else the package's own dir.
 			cursor = pkg.resolvedPath !== pkg.path ? pkg.resolvedPath : key;

--- a/test/util/packages.js
+++ b/test/util/packages.js
@@ -148,6 +148,34 @@ let chainedLinksPackages = new Packages(
 	},
 );
 
+// Case G: npm-linked to global store, no child lockfile.
+// Transitive dep is hoisted in the root lockfile only.
+let globalLinkedPackages = new Packages({
+	packages: {
+		"node_modules/@ns/core": { link: true, resolved: "../../.nvm/lib/node_modules/@ns/core" },
+		"../../.nvm/lib/node_modules/@ns/core": {
+			version: "3.0.0",
+			name: "@ns/core",
+			dependencies: { hooks: "^0.0" },
+		},
+		"node_modules/hooks": { version: "0.0.2", name: "hooks" },
+	},
+});
+
+// Case G variant: same as G, but the hoisted transitive dep is also npm-linked.
+let globalLinkedBothPackages = new Packages({
+	packages: {
+		"node_modules/@ns/core": { link: true, resolved: "../../.nvm/lib/node_modules/@ns/core" },
+		"../../.nvm/lib/node_modules/@ns/core": {
+			version: "3.0.0",
+			name: "@ns/core",
+			dependencies: { hooks: "^0.0" },
+		},
+		"node_modules/hooks": { link: true, resolved: "../../.nvm/lib/node_modules/hooks" },
+		"../../.nvm/lib/node_modules/hooks": { version: "0.0.2", name: "hooks" },
+	},
+});
+
 let dir = "./client_modules";
 
 /**
@@ -415,6 +443,34 @@ export default {
 				{ arg: "path", expect: "../../packages/pkg-a/node_modules/color-name" },
 				{ arg: "sourcePath", expect: "../../packages/pkg-a/node_modules/color-name" },
 				{ arg: "localDir", expect: "./client_modules/color-name@2.1.0" },
+			],
+		},
+		// Case G: npm-linked to global store, no child lockfile.
+		{
+			name: "./node_modules/@ns/core/node_modules/hooks/src/index.js",
+			description:
+				"Transitive dep hoisted in root lockfile, no child lockfile for linked package",
+			packages: globalLinkedPackages,
+			tests: [
+				{ arg: "name", expect: "hooks" },
+				{ arg: "version", expect: "0.0.2" },
+				{ arg: "path", expect: "./node_modules/hooks" },
+				{ arg: "sourcePath", expect: "./node_modules/hooks" },
+				{ arg: "localDir", expect: "./client_modules/hooks@0.0.2" },
+			],
+		},
+		// Case G variant: transitive dep is also npm-linked.
+		{
+			name: "./node_modules/@ns/core/node_modules/hooks/src/index.js",
+			description: "Both the parent and the hoisted transitive dep are npm-linked",
+			packages: globalLinkedBothPackages,
+			tests: [
+				{ arg: "name", expect: "hooks" },
+				{ arg: "version", expect: "0.0.2" },
+				{ arg: "isExternal", expect: true },
+				{ arg: "path", expect: "./node_modules/hooks" },
+				{ arg: "sourcePath", expect: "./node_modules/hooks" },
+				{ arg: "localDir", expect: "./client_modules/hooks@0.0.2" },
 			],
 		},
 	],


### PR DESCRIPTION
## Summary

- When a dependency is `npm link`ed to the global store, `parse()` fails to find its transitive deps. Global installs don't produce a per-package `.package-lock.json`, so the child lockfile merge in the `Packages` constructor has nothing to load. The transitive deps ARE hoisted into the consumer project's root lockfile by npm, but `parse()`'s chain-walking loop only looked under the linked package's resolved path and gave up when the key wasn't there — returning `pkg=null` and producing broken import map entries like `./client_modules/src/index.js` (missing package name and version)
- Fall back to the hoisted root-level entry when the resolved-path lookup fails

## Test plan

- [x] New unit test (Case G) confirms `parse()` resolves name, version, path, sourcePath, and localDir correctly
- [x] Variant test confirms it also works when the hoisted transitive dep is itself npm-linked (`isExternal: true`)
- [x] Full test suite passes (112/112)
- [x] Real-world verification: `npm link @inspirejs/core inspirejs.org @inspirejs/plugins` in `talks/`, then ran nudeps on `talks/whathecolor/` — `blissful-hooks` import map entry and `client_modules/` copy are both correct
- [x] All 18 import map entries in `whathecolor/importmap.js` resolve to real files

Closes #116