### PR TITLE
Fix config hooks not reaching Nudeps constructor

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -66,6 +66,7 @@ Config file uses ES module syntax: `export default { ... }`.
 | `cjs`     | `true`             | Include CJS shim for CommonJS packages                                                                                                                   |
 | `prune`   | `false`            | Subset import map to only used specifiers                                                                                                                |
 | `alias`   | `true`             | Unversioned symlinks for stable asset URLs (CSS, images). Use the unversioned path in HTML/CSS (e.g., `<link href="[output-dir]/open-props/style.css">`) |
+| `hooks`   | —                  | Object of lifecycle hook callbacks (e.g., `constructed`, `create-aliases-start`). See [blissful-hooks](https://github.com/LeaVerou/blissful-hooks) |
 
 Full option reference and troubleshooting: see README.md in the nudeps package directory.
 

--- a/src/options.js
+++ b/src/options.js
@@ -46,6 +46,10 @@ export const overrides = {
 	cli: false,
 };
 
+export const hooks = {
+	cli: false,
+};
+
 export const module = {
 	default: false,
 };


### PR DESCRIPTION
## Summary
- Add `hooks` to the options registry in `src/options.js` so `getConfig()` includes it in the returned config object
- Without this, hooks defined in `nudeps.js` config files were silently dropped before reaching the constructor
- Document `hooks` in `SKILL.md` config table

Rel. to #75

## Test plan
- [x] Existing tests pass (`npx htest ./test/index.js`)
- [x] Demos regenerate successfully (`npm run demos`)
- [x] Verified manually: a `constructed` hook in a demo's `nudeps.js` fires on `npx nudeps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)