### PR TITLE
Ignore .d.ts files in JSPM wildcard export tracing

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -32,7 +32,10 @@ export class ImportMapGenerator extends Generator {
 			flattenScopes: false,
 			combineSubpaths: false,
 			commonJS: true,
-			ignore: getNodeBuiltins(),
+			// Skip .d.ts files whose presence in wildcard exports causes
+			// JSPM trace failures (jspm/jspm#2717, #122).
+			ignore: specifier =>
+				getNodeBuiltins().includes(specifier) || /\.d\.[cm]?ts(\.map)?$/.test(specifier),
 			...generatorOptions,
 		});
 


### PR DESCRIPTION
## Summary

- JSPM's `subpaths: true` traces `.d.ts` files from wildcard exports even when `"types"` isn't in `env`, causing trace failures for packages like `colorjs.io` (jspm/jspm#2717)
- Use JSPM's function form of `ignore` to skip `.d.ts` specifiers during tracing, so named subpath exports (e.g. `colorjs.io/spaces`) are no longer lost

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)