### PR TITLE
Fix ensureSymlink failing on dangling alias symlinks (EEXIST)

### DIFF
--- a/src/util/fs.js
+++ b/src/util/fs.js
@@ -7,6 +7,7 @@ import {
 	opendirSync,
 	symlinkSync,
 	readlinkSync,
+	unlinkSync,
 	rmSync,
 } from "node:fs";
 import * as path from "node:path";
@@ -145,6 +146,11 @@ export function ensureSymlink (target, linkPath, type, { force } = {}) {
 	catch {}
 
 	if (force) {
+		try {
+			// rmSync alone skips dangling symlinks (#124)
+			unlinkSync(linkPath);
+		}
+		catch {}
 		rmSync(linkPath, { recursive: true, force: true });
 	}
 


### PR DESCRIPTION
## Summary

- `rmSync({recursive: true, force: true})` silently skips dangling symlinks — added `unlinkSync` before it to handle them

## No regressions

| Case | `unlinkSync` | `rmSync` | Same as before? |
|---|---|---|---|
| **Doesn't exist** | throws ENOENT → caught | no-ops (`force` swallows ENOENT) | Yes |
| **Valid symlink** | removes it | no-ops (gone already) | Yes |
| **Directory** | throws EPERM/EISDIR → caught | removes it | Yes |
| **Regular file** | removes it | no-ops | Yes |
| **Permission denied** | throws EACCES → caught | throws EACCES (same as before) | Yes |
| **Dangling symlink** | removes it | no-ops | **Fixed** |

Closes #124