### PR TITLE
Fix wildcard exports with conditional targets (#126)

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -4,7 +4,7 @@
 import { Generator } from "@jspm/generator";
 
 import { deepAssign, getNodeBuiltins } from "./util.js";
-import { findOverride } from "./util/jspm-overrides.js";
+import { findOverride, stripConditions } from "./util/jspm-overrides.js";
 import nudepsPkg from "../package.json" with { type: "json" };
 
 /**
@@ -51,8 +51,11 @@ export class ImportMapGenerator extends Generator {
 		// sub-generators created on cache miss still produce user-facing log messages.
 		this._options = { mode, nudeps, ...generatorOptions };
 
-		// Apply JSPM community overrides (client-side equivalent of what jspm.io CDN does server-side)
+		// Patch package configs before JSPM resolves them:
+		// 1. Apply community overrides (client-side equivalent of what jspm.io CDN does server-side)
+		// 2. Strip non-runtime export conditions that shadow `default` in wildcards (#126)
 		let pm = this.provider;
+		let { env } = this.traceMap.resolver;
 		pm._getPackageConfig = pm.getPackageConfig;
 		pm.getPackageConfig = async function (pkgUrl) {
 			let pcfg = await pm._getPackageConfig(pkgUrl);
@@ -62,6 +65,11 @@ export class ImportMapGenerator extends Generator {
 					Object.assign(pcfg, override);
 				}
 			}
+
+			if (pcfg?.exports) {
+				pcfg.exports = stripConditions(pcfg.exports, env);
+			}
+
 			return pcfg;
 		};
 	}

--- a/src/util/jspm-overrides.js
+++ b/src/util/jspm-overrides.js
@@ -10,11 +10,19 @@
 import overrides from "@jspm/overrides" with { type: "json" };
 export { overrides };
 
+const EXPORT_CONDITIONS_BLACKLIST = ["types", "typings"];
+
 /**
- * Strip export conditions not in `conditions`, so non-runtime ones
- * don't shadow `default` in JSPM's wildcard resolution (jspm/jspm#2717).
+ * Strip export conditions that would shadow `default` in JSPM's wildcard
+ * resolution (jspm/jspm#2717). At each object level:
+ * - If any sibling is known (in `conditions` or is `default`), drop the unknown
+ *   siblings — JSPM has a resolution to pick, the rest get in the way.
+ * - Otherwise leave the object alone; we can't tell which condition would resolve.
+ *
+ * `types`/`typings` are always stripped: they resolve to `.d.ts` files which
+ * break JSPM tracing even when they're the only condition.
  * @param {import("@jspm/generator").ExportsTarget} exports
- * @param {string[]} conditions
+ * @param {string[]} conditions - Recognized export conditions (JSPM resolver env)
  * @returns {import("@jspm/generator").ExportsTarget}
  */
 export function stripConditions (exports, conditions) {
@@ -27,11 +35,18 @@ export function stripConditions (exports, conditions) {
 		return exports.map(item => stripConditions(item, conditions));
 	}
 
+	let hasKnown = Object.keys(exports).some(key => key === "default" || conditions.includes(key));
+
 	let ret = {};
 	for (let key in exports) {
-		if (key.startsWith(".") || key === "default" || conditions.includes(key)) {
-			ret[key] = stripConditions(exports[key], conditions);
+		if (
+			EXPORT_CONDITIONS_BLACKLIST.includes(key) ||
+			(hasKnown && key !== "default" && !conditions.includes(key))
+		) {
+			continue;
 		}
+
+		ret[key] = stripConditions(exports[key], conditions);
 	}
 
 	return ret;

--- a/src/util/jspm-overrides.js
+++ b/src/util/jspm-overrides.js
@@ -11,6 +11,33 @@ import overrides from "@jspm/overrides" with { type: "json" };
 export { overrides };
 
 /**
+ * Strip export conditions not in `conditions`, so non-runtime ones
+ * don't shadow `default` in JSPM's wildcard resolution (jspm/jspm#2717).
+ * @param {import("@jspm/generator").ExportsTarget} exports
+ * @param {string[]} conditions
+ * @returns {import("@jspm/generator").ExportsTarget}
+ */
+export function stripConditions (exports, conditions) {
+	if (!exports || typeof exports !== "object") {
+		return exports;
+	}
+
+	if (Array.isArray(exports)) {
+		// Fallback array: strip each alternative
+		return exports.map(item => stripConditions(item, conditions));
+	}
+
+	let ret = {};
+	for (let key in exports) {
+		if (key.startsWith(".") || key === "default" || conditions.includes(key)) {
+			ret[key] = stripConditions(exports[key], conditions);
+		}
+	}
+
+	return ret;
+}
+
+/**
  * Find the best matching override for a given package name and version.
  * Override keys like "3" or "16.8.0" mean "same major, >= this version".
  * Among multiple matches, the most specific (most segments) wins.

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -1,7 +1,8 @@
+import jspmOverridesTests from "./jspm-overrides.js";
 import packagesTests from "./packages.js";
 import readJSONTests from "./read-json.js";
 
 export default {
 	name: "util tests",
-	tests: [packagesTests, readJSONTests],
+	tests: [jspmOverridesTests, packagesTests, readJSONTests],
 };

--- a/test/util/jspm-overrides.js
+++ b/test/util/jspm-overrides.js
@@ -1,0 +1,48 @@
+import { stripConditions } from "../../src/util/jspm-overrides.js";
+
+export default {
+	name: "stripConditions",
+	run: exports => stripConditions(exports, ["production", "browser", "module", "import"]),
+	tests: [
+		{
+			name: "Strips types condition shadowing default (#126)",
+			arg: {
+				"./src/*": {
+					import: {
+						types: "./types/src/*",
+						default: "./src/*",
+					},
+				},
+				"./dist/*": "./dist/*",
+			},
+			expect: {
+				"./src/*": {
+					import: {
+						default: "./src/*",
+					},
+				},
+				"./dist/*": "./dist/*",
+			},
+		},
+		{
+			name: "Recurses into array fallback targets",
+			arg: {
+				"./x": [
+					{
+						types: "./types/x.d.ts",
+						default: "./esm/x.js",
+					},
+					"./cjs/x.cjs",
+				],
+			},
+			expect: {
+				"./x": [
+					{
+						default: "./esm/x.js",
+					},
+					"./cjs/x.cjs",
+				],
+			},
+		},
+	],
+};

--- a/test/util/jspm-overrides.js
+++ b/test/util/jspm-overrides.js
@@ -44,5 +44,15 @@ export default {
 				],
 			},
 		},
+		{
+			name: "Allowlist mode drops unknown conditions in favor of default",
+			arg: { "./x": { deno: "./d.js", default: "./def.js" } },
+			expect: { "./x": { default: "./def.js" } },
+		},
+		{
+			name: "Blocklist mode keeps unknowns but still drops types/typings",
+			arg: { "./x": { deno: "./d.js", types: "./d.ts", typings: "./d2.ts" } },
+			expect: { "./x": { deno: "./d.js" } },
+		},
 	],
 };


### PR DESCRIPTION
## Summary

Patches the `getPackageConfig` hook to rewrite each package's `exports` before JSPM's wildcard resolver sees it, fixing the bug where unknown conditions (e.g. `types`) greedily shadow `default` in JSPM's `expandTargetResolutions` (jspm/jspm#2717).

**Per-object rule** (per @LeaVerou's review):
- If any sibling is a known condition (in `resolver.env` or `default`), drop the unknown siblings — JSPM has a resolution to pick, the rest get in the way.
- Otherwise leave the object alone; we can't tell which condition would resolve.

**Hard blacklist**: `types`/`typings` are always stripped — they resolve to `.d.ts` files which break JSPM tracing even when alone.

Closes #126