### PR TITLE
Fix wrong package resolution in npm workspaces

### DIFF
--- a/src/util/packages.js
+++ b/src/util/packages.js
@@ -17,22 +17,37 @@ export default class Packages {
 	#parseCache = {};
 
 	/**
-	 * Find the nearest ancestor (or `cwd` itself) with `node_modules/.package-lock.json`.
-	 * In npm workspaces this is the monorepo root; npm never writes the hidden
-	 * lockfile inside workspace children, even those with their own `node_modules/`.
+	 * Find the nearest `node_modules/.package-lock.json` ancestor, preferring
+	 * the workspace root's lockfile when inside an npm workspace.
 	 * @param {string} [cwd]
 	 * @returns {string|null}
 	 */
 	static findRoot (cwd = process.cwd()) {
+		let found = null;
 		let dir = cwd;
-		while (!existsSync(path.join(dir, "node_modules", ".package-lock.json"))) {
+
+		while (true) {
+			if (existsSync(path.join(dir, "node_modules", ".package-lock.json"))) {
+				// Don't stop — child lockfiles can be stale after workspace hoisting
+				found ??= dir;
+
+				// Only adopt this workspace root if our project is actually a member
+				let workspaces = readJSONSync(path.join(dir, "package.json"), { optional: true })?.workspaces;
+				if (workspaces) {
+					let member = path.relative(dir, found);
+					if (workspaces.some(workspace => path.matchesGlob(member, workspace))) {
+						return dir;
+					}
+					return found;
+				}
+			}
+
 			let parent = path.dirname(dir);
 			if (parent === dir) {
-				return null;
+				return found;
 			}
 			dir = parent;
 		}
-		return dir;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

When a workspace child retains a `node_modules/.package-lock.json` from a pre-hoisting install (e.g. after `npm link`), `findRoot()` stopped there instead of walking up to the workspace root. This caused `pkg.path` to point into the child's empty `node_modules/`, producing broken symlinks in `client_modules/` — even after deleting and re-running nudeps.

The fix makes `findRoot()` record the first lockfile it finds but keep walking; if a parent has a `package.json` with `"workspaces"` and its own lockfile, that directory is returned instead — but only if the child's path actually matches the `workspaces` globs, so standalone projects nested inside unrelated workspaces aren't misidentified.

Single loop, no downstream changes needed — `prefix`, `pkg.path`, and all symlink targets become correct automatically.

Rel. to #101.

## Test plan

- [x] Full test suite passes (136/136)
- [x] All 13 demos regenerate successfully (`npm run init-demos`)
- [x] Verified with filesystem fixtures: standalone, clean workspace, stale lockfile, glob patterns, unrelated workspace, no lockfile, running from root