### PR TITLE
Fix copyPackages() silently keeping dangling symlinks

### DIFF
--- a/src/nudeps.js
+++ b/src/nudeps.js
@@ -2,7 +2,7 @@
  * Main entry point
  */
 
-import { existsSync, rmSync, rmdirSync, cpSync, symlinkSync, mkdirSync } from "node:fs";
+import { existsSync, unlinkSync, rmSync, rmdirSync, cpSync, symlinkSync, mkdirSync } from "node:fs";
 import * as path from "node:path";
 import { execSync } from "node:child_process";
 
@@ -537,10 +537,16 @@ export default class Nudeps {
 			let { pkg } = this.packages.parse(from);
 
 			let exists = existingDirs.has(to);
-			let needsRecreate = exists && existingSymlinks.has(to) !== this.shouldSymlink(pkg);
+			let needsRecreate =
+				exists && (existingSymlinks.has(to) !== this.shouldSymlink(pkg) || !existsSync(to));
 
 			if (needsRecreate) {
-				rmSync(to, { recursive: true });
+				if (existingSymlinks.has(to)) {
+					unlinkSync(to);
+				}
+				else {
+					rmSync(to, { recursive: true });
+				}
 				toDelete.delete(to);
 			}
 


### PR DESCRIPTION
## Summary

After `npm link` hoists packages to the workspace root, existing `client_modules/` symlinks become dangling. `copyPackages()` only checked the entry type (symlink vs directory) when deciding whether to recreate, never whether the symlink target actually resolves — so dangling symlinks were silently preserved as "unchanged."

Additionally, `rmSync({ recursive: true })` silently skips dangling symlinks (same Node.js behavior that caused #124 in `ensureSymlink`), so even after detecting them the removal would fail and `symlinkSync` would throw EEXIST.

**Two changes in `src/nudeps.js`:**
- `needsRecreate` now also fires when `existsSync(to)` returns false (entry listed by `readdirSync` but target doesn't resolve = dangling symlink)
- Symlink entries are removed with `unlinkSync` (operates on the link itself) instead of `rmSync` (follows the target, silently no-ops on dangling links). Directories still use `rmSync({ recursive: true })`

Rel. to #101.

## Test plan

- [x] Existing test suite passes (136/136)
- [x] Manual: `npm install` → `npm link <pkg>` → `npx nudeps` in a workspace child — dangling symlinks should be replaced, not reported as "unchanged"

🤖 Generated with [Claude Code](https://claude.com/claude-code)