### PR TITLE
Aggregate workspace redirect rules into root _redirects

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -96,7 +96,7 @@ nudeps logs a summary after each run: number of import map entries, time taken, 
 
 ## npm Workspaces
 
-Running nudeps inside a workspace package works: it finds the lockfile at the monorepo root (deps are hoisted there), so hoisted dependencies and sibling workspace packages both resolve — hoisted deps get copied, siblings get symlinked into the package's output dir. `npx nudeps install` in a workspace child automatically adds `dependencies` and `prepare` hooks to the workspace root that delegate to children (`npm run <hook> --if-present --workspaces`), so `npm install` at the root triggers import map generation in each child. Limitation: change propagation between sibling workspace packages is not wired up.
+Running nudeps inside a workspace package works: it finds the lockfile at the monorepo root (deps are hoisted there), so hoisted dependencies and sibling workspace packages both resolve — hoisted deps get copied, siblings get symlinked into the package's output dir. `npx nudeps install` in a workspace child automatically adds `dependencies` and `prepare` hooks to the workspace root that delegate to children (`npm run <hook> --if-present --workspaces`), so `npm install` at the root triggers import map generation in each child. On Netlify (and Cloudflare), workspace children write redirect rules to the **root** `_redirects` with the child directory as a path prefix — no per-child `_redirects` is created. Limitation: change propagation between sibling workspace packages is not wired up.
 
 ## Programmatic API
 

--- a/src/hosts.js
+++ b/src/hosts.js
@@ -14,15 +14,19 @@ export const netlify = {
 			}
 
 			// Netlify doesn't support symlinks, add _rewrites
-			let redirectsFile = fs.openSync("_redirects", "a");
+			// In a workspace child, prefix paths with the child dir and write to root
+			// e.g. /child/client_modules/foo/* /child/client_modules/foo@1.0.0/:splat 302
+			let { prefix } = this.packages;
+			let pathPrefix = prefix ? path.relative(path.resolve(prefix), process.cwd()) + "/" : "";
+
 			let redirects = aliasEntries
 				.map(
 					([aliasPath, target]) =>
-						`/${aliasPath}/* /${path.join(path.dirname(aliasPath), target)}/:splat 302`,
+						`/${pathPrefix}${aliasPath}/* /${pathPrefix}${path.join(path.dirname(aliasPath), target)}/:splat 302`,
 				)
 				.join("\n");
-			fs.writeSync(redirectsFile, `${redirects}\n`);
-			fs.closeSync(redirectsFile);
+
+			fs.appendFileSync(path.join(prefix, "_redirects"), `${redirects}\n`);
 		},
 	},
 };


### PR DESCRIPTION
## Summary

- When deploying an npm workspace to Netlify (or Cloudflare), child projects' `_redirects` files are ignored — Netlify only reads from the publish root
- The Netlify host `create-aliases-end` hook now detects workspace membership via `this.packages.prefix` and writes redirect rules to the **root** `_redirects` with the child directory as a path prefix
- Standalone (non-workspace) projects are unaffected — same local `_redirects` behavior as before
- Replaces `openSync`/`writeSync`/`closeSync` with `appendFileSync`

### How it works

`packages.prefix` is the relative path from CWD to the workspace root (e.g., `".."` for a flat child, `"../.."` for a nested one). When non-empty, the hook:

1. Computes the child directory: `path.relative(path.resolve(prefix), process.cwd())` → e.g., `"whathecolor"`
2. Prefixes all redirect paths: `/whathecolor/client_modules/foo/* /whathecolor/client_modules/foo@1.0.0/:splat 302`
3. Writes to `path.join(prefix, "_redirects")` (the root file) instead of the local `_redirects`

### Concurrency safety

Not a concern — nudeps skips the implicit (parallel) `prepare` during npm's reify phase (`src/index.js:12-24`). The actual execution runs via `npm run prepare --if-present --workspaces` which is **sequential**.

### Idempotency

- **Netlify**: fresh clone → file absent → append-only produces clean results
- **Local re-runs**: duplicates accumulate (same as existing standalone behavior, harmless — nothing consumes `_redirects` locally)

## Verified

- Workspace children (flat `child-a/` and nested `packages/nested-child/`): correct prefixed rules in root `_redirects`
- Child with no aliases: no write (early return)
- No local `_redirects` created in workspace children
- All 13 standalone demos: correct unprefixed local `_redirects`, including scoped packages (`@floating-ui/*`, `@vue/*`)
- Real-world test: `talks` workspace with `whathecolor` child — 17 correctly prefixed rules, presentation loads and navigates
- `npm test`: 137/137 pass
- `npm run demos`: all demos rebuild successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)