### PR TITLE
Add clientDependencies support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,15 @@ export default async function (options) {
 		var rootInstallError = e;
 	}
 
+	// Surface promoted clientDependencies as regular deps so the trace below picks them up.
+	// Skipped in prune mode — that path doesn't pre-install pkg.dependencies either.
+	if (!config.prune && nudeps.packages.clientDependencies?.size) {
+		nudeps.pkg.dependencies ??= {};
+		for (let name of nudeps.packages.clientDependencies) {
+			nudeps.pkg.dependencies[name] ??= "*";
+		}
+	}
+
 	if (!config.prune && nudeps.pkg.dependencies) {
 		let exclude = new Set(config.exclude ?? []);
 

--- a/src/map.js
+++ b/src/map.js
@@ -72,9 +72,12 @@ export class ImportMapGenerator extends Generator {
 
 	async install (alias, target, { noRetry, ...installOptions } = {}) {
 		if (target === undefined) {
-			// Locate the dep in node_modules — at the monorepo root (prefix) under workspaces.
-			let prefix = this.nudeps?.packages.prefix ?? "";
-			target = `${prefix ? prefix + "/" : "./"}node_modules/${alias}`;
+			// Use the Packages-known install path — handles workspace prefix + nested deps
+			// (e.g., promoted clientDependencies inside a linked dev tool's tree).
+			target = this.nudeps?.packages.get(alias)?.path;
+			if (target === undefined) {
+				throw new Error(`Cannot find "${alias}" in lockfile.`);
+			}
 		}
 
 		// Check if this install is cacheable:

--- a/src/nudeps.js
+++ b/src/nudeps.js
@@ -203,7 +203,7 @@ export default class Nudeps {
 	}
 
 	get packages () {
-		let value = Packages.load(process.cwd(), { warn: msg => this.info(msg) });
+		let value = Packages.load(process.cwd(), { warn: msg => this.info(msg), pkg: this.pkg });
 		Object.defineProperty(this, "packages", { value, configurable: true });
 		return value;
 	}

--- a/src/util/packages.js
+++ b/src/util/packages.js
@@ -57,9 +57,10 @@ export default class Packages {
 	 * @param {string} [cwd]
 	 * @param {object} [options]
 	 * @param {(message: string) => void} [options.warn] - Called for non-fatal lockfile issues.
+	 * @param {object} [options.pkg] - Consumer's parsed package.json. Its `devDependencies` seed the clientDependencies chain.
 	 * @returns {Packages}
 	 */
-	static load (cwd = process.cwd(), { warn = () => {} } = {}) {
+	static load (cwd = process.cwd(), { warn = () => {}, pkg } = {}) {
 		let dir = Packages.findRoot(cwd);
 
 		if (dir === null) {
@@ -114,7 +115,65 @@ export default class Packages {
 			}
 		}
 
-		return new Packages(data, { children, prefix });
+		// Promote clientDependencies past the dev filter by flipping `dev: true` →
+		// `dev: false` on promoted entries. Custom fields aren't in the lockfile, so we
+		// read each dev tool's package.json — but only along the chain from cwd's
+		// devDependencies, not every dev entry. Child lockfile entries are flipped too.
+		let clientDependencies = new Set();
+		let toCheck = new Set(Object.keys(pkg?.devDependencies ?? {}));
+
+		if (toCheck.size) {
+			let lockfiles = [
+				[raw, dir],
+				...Object.entries(children).map(([childPath, childData]) => [
+					childData.packages ?? {},
+					path.resolve(cwd, childPath),
+				]),
+			];
+
+			// Names added during iteration are picked up by Set-mutation-during-`for...of`.
+			for (let name of toCheck) {
+				let suffix = "node_modules/" + name;
+				let chainRead = false;
+				for (let [pkgs, lockfileDir] of lockfiles) {
+					for (let key in pkgs) {
+						if (key !== suffix && !key.endsWith("/" + suffix)) {
+							continue;
+						}
+
+						// Read declarations once per name. Within each lockfile, prefer the hoisted
+						// entry (the `!pkgs[suffix]` check); across lockfiles, root wins by
+						// iteration order. Multiple same-name nested copies in one lockfile: first wins.
+						if (!chainRead && (key === suffix || !pkgs[suffix])) {
+							chainRead = true;
+							let depPkg = readJSONSync(path.join(lockfileDir, key, "package.json"), {
+								optional: true,
+							});
+							for (let declared of depPkg?.clientDependencies ?? []) {
+								// Consumer's own declaration wins — listing in `devDependencies`
+								// overrides a tool's attempt to promote the same name to runtime.
+								if (pkg?.devDependencies?.[declared]) {
+									warn(`'${declared}' is a devDependency but also promoted as a clientDependency by '${name}'. Skipping — move '${declared}' to dependencies to expose it.`);
+									continue;
+								}
+								clientDependencies.add(declared);
+								toCheck.add(declared);
+							}
+						}
+
+						if (clientDependencies.has(name)) {
+							pkgs[key].dev = false;
+							for (let dep in pkgs[key]?.dependencies) {
+								clientDependencies.add(dep);
+								toCheck.add(dep);
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return new Packages(data, { children, prefix, clientDependencies });
 	}
 
 	/**
@@ -122,9 +181,11 @@ export default class Packages {
 	 * @param {object} [options]
 	 * @param {object} [options.children] - Child lockfile data keyed by resolved path, for merging transitive deps of local deps
 	 * @param {string} [options.prefix] - cwd→lockfile-dir path (e.g. "../..") for workspaces, to rebase paths to cwd. Keys stay as-is for URL matching.
+	 * @param {Set<string>} [options.clientDependencies] - Install names of packages `load()` promoted by flipping `dev: true` → `dev: false`. Caller reads this to inject promoted names into the consumer's `pkg.dependencies` for JSPM tracing.
 	 */
-	constructor (data, { children = {}, prefix = "" } = {}) {
+	constructor (data, { children = {}, prefix = "", clientDependencies } = {}) {
 		this.prefix = prefix;
+		this.clientDependencies = clientDependencies;
 		let raw = data?.packages ?? {};
 
 		// Rebase a lockfile-relative path to cwd (no prefix keeps the historical "./" form).


### PR DESCRIPTION
## Summary

A `clientDependencies` field in a package's own `package.json` declares which of *its* dependencies should be promoted to a consumer's import map when the package is installed as a `devDependency`. **The consumer declares nothing** — installing the package is enough.

```jsonc
// site-builder/package.json — declared by the dev tool
{
  "name": "site-builder",
  "dependencies": { "widget-lib": "^1.0.0" },
  "clientDependencies": ["widget-lib"]
}
```

When Nudeps runs in a consumer that has `site-builder` as a `devDependency`, it walks the declaration chain starting from the consumer's `devDependencies`, reads each candidate's `package.json`, and promotes the declared names by flipping their `dev` flag in the lockfile data. From that point on the rest of Nudeps treats them as regular runtime deps — same paths, same import-map entries, same copying. Scoped packages and npm install aliases work without special handling.

Declarations chain: if `widget-lib` itself declares `clientDependencies`, those are picked up too — the BFS keeps walking until no new names appear.

Closes #131.

## Why

Build tools (e.g. static-site generators) ship browser code that depends on UI libraries. The consumer installs the tool as a `devDependency` and never imports the UI library directly — but the UI library must still resolve in the browser. Without `clientDependencies`, the consumer has to redeclare it as a `dependency`, leaking the tool's internals and drifting out of sync with the tool's version.

## How

`Packages.load()` does the discovery + flip in one walk; the JSPM-trace injection lives at the call site:

1. **Seed.** Use the consumer's `pkg.devDependencies` keys as the starting set. (Nudeps passes its already-read `this.pkg` to `load()` to avoid a redundant read.)
2. **BFS.** For each name in the queue, find a matching lockfile entry (prefer hoisted), read its `package.json`, and add any declared `clientDependencies` names back into the queue + into the promoted `Set` — skipping names the consumer also lists in `devDependencies` (see *Inconsistent declarations are rejected* below). Names added during iteration are picked up in the same `for…of` via Set-mutation-during-iteration.
3. **Flip + transitive.** In the same loop, if the current name is already in the promoted `Set`, set `dev: false` on every install-path match (hoisted *and* nested, across root *and* child lockfiles) and queue its lockfile `dependencies` for promotion.
4. **Expose + inject (at the call site).** `Packages.load()` returns a `Packages` whose `.clientDependencies` is the promoted `Set` — no mutation of the caller's `pkg`. `src/index.js`, immediately before the `for (const dep in nudeps.pkg.dependencies)` loop that drives JSPM, iterates that set and injects each name into `nudeps.pkg.dependencies` with `??= "*"` (never overwriting an explicit version). The injection lives where it's *used*, so there's no eager work elsewhere and no hidden side effect of accessing a lazy getter. Skipped in prune mode (the dep-install loop is also gated on `!config.prune`).

The `Packages` constructor stays unchanged — its dev filter is pure `info.dev`. The flip in step 3 is what makes promoted entries naturally pass the filter; no override needed.

**Drive-by fix.** `ImportMapGenerator#install(alias)` now resolves the install target via `Packages.get(alias)?.path` — the source of truth for *where* each dep lives on disk, including non-hoisted paths inside linked trees. This replaces a hardcoded `prefix/node_modules/<alias>` heuristic that was correct for hoisted deps (all this code ever installed pre-`clientDependencies`) but produces a non-existent path for the nested cases this feature introduces. Strictly a feature-induced bug, not a pre-existing one — but worth calling out as a fix. When the lookup misses (alias in `pkg.dependencies` but absent from the lockfile), `install()` throws `Cannot find "<alias>" in lockfile` rather than passing `undefined` downstream — a clearer failure mode than the previous heuristic's "package not found at non-existent path".

### Why this avoids the obvious shortcuts

- **Why not read all `dev: true` entries' `package.json`?** Earlier drafts did. It's bounded I/O but it's I/O proportional to the *entire* dev tree (often hundreds of files). The BFS-from-seed approach reads only along the chain — typically a handful.
- **Why not hook into JSPM Generator's reads?** JSPM strips unknown package.json fields via `trimPackageConfig` (in `@jspm/generator` since 2.14), so `clientDependencies` doesn't survive a round-trip through its resolver cache. JSPM also runs *after* `Packages.load()`, so it can't influence the dev filter regardless.
- **Behavioral tightening (intentional).** A transitive dev-dep that declares `clientDependencies` but isn't itself in the chain is now ignored. That's the right semantic — a sub-tool's client deps shouldn't leak if no one promoted it — but it's a change from earlier drafts of this PR.
- **Inconsistent declarations are rejected.** If a `clientDependencies` entry names something the consumer also lists in `devDependencies`, `load()` warns and skips. The consumer's own `devDependencies` declares the name as dev-only; promoting it anyway would silently contradict that. Move it to `dependencies` to expose it.

## Verification

- [x] All 135 tests pass
- [x] **Verdaccio end-to-end (single declaration)**: published `site-builder@1.0.0` with `clientDependencies: ["@floating-ui/dom"]`. `my-site` installs it as a devDep + `preact` as a regular dep + `prettier` as an unrelated devDep. After `npx nudeps --init`:
  - `@floating-ui/dom` + transitive `@floating-ui/core` + `@floating-ui/utils` → in import map and `client_modules` with aliases ✓
  - `preact` (regular dep) → in import map ✓
  - `prettier` (non-promoted devDep) → excluded ✓
  - `site-builder` (the declaring tool itself) → excluded ✓
- [x] **Verdaccio end-to-end (chained declarations)**: published a 3-package chain — `nudeps-chain-builder` declares `nudeps-chain-widget`; `nudeps-chain-widget` declares `nudeps-chain-polyfill`. `my-site` installs only `nudeps-chain-builder` as a devDep. After `npx nudeps --init`:
  - `nudeps-chain-widget` → in import map and `client_modules` ✓
  - `nudeps-chain-polyfill` (declared by widget, not builder) → in import map and `client_modules` ✓
  - `nudeps-chain-builder` (the top-level declarer) → excluded ✓
- [x] **Verdaccio end-to-end (nested install via version conflict)**: published `nudeps-conflict-widget@1.0.0` (depends on `nudeps-conflict-inner`) and `nudeps-conflict-widget@2.0.0` (no `inner` dep). `nudeps-conflict-builder@1.0.0` pins widget `1.0.0` and declares `clientDependencies: ["nudeps-conflict-widget"]`. `my-site` has `widget@^2.0.0` as a regular dep (hoists v2 to root) and `builder@^1.0.0` as a devDep (nests v1 under `builder`). After `npx nudeps --init`:
  - `nudeps-conflict-widget` → in import map ✓
  - `nudeps-conflict-inner` → in import map ✓ (declared by the nested `widget@1.0.0`)
  - `nudeps-conflict-builder` (the declaring tool itself) → excluded ✓
- [x] **Verdaccio end-to-end (npm install alias)**: published `nudeps-alias-actual@1.0.0` and `nudeps-alias-tool@1.0.0`. The tool depends on the actual package under an aliased name (`"nudeps-alias-aliased": "npm:nudeps-alias-actual@^1.0.0"`) and declares `clientDependencies: ["nudeps-alias-aliased"]`. `my-site` installs only the tool as a devDep. After `npx nudeps --init`:
  - Import map specifier `nudeps-alias-aliased` → `./client_modules/nudeps-alias-actual@1.0.0/lib/index.js` ✓
  - `client_modules/nudeps-alias-actual@1.0.0/` holds the actual package's contents; `client_modules/nudeps-alias-aliased@` is an unversioned alias symlink to it ✓
  - `nudeps-alias-tool` (the declaring tool itself) → excluded ✓
- [x] **`npm link` (linked dev tool)**: published `widget-lib@1.0.0` to Verdaccio. Created a local `linked-builder` package (registry-installed `widget-lib`, declared `clientDependencies: ["widget-lib"]`). `npm link`'d `linked-builder` into `my-site` as a devDep — so `linked-builder` is a symlink and `widget-lib` lives inside the linked tree, not at `my-site/node_modules/widget-lib`. After `npx nudeps --init`:
  - Chain read worked through the symlink (load() resolved `clientDependencies` from the linked builder's `package.json`) ✓
  - Import map: `widget-lib` → `./client_modules/widget-lib@1.0.0/index.js` ✓
  - `client_modules/widget-lib@1.0.0` symlinks to `../../linked-builder/node_modules/widget-lib` (the actual file location) ✓
  - `linked-builder` (the symlinked declarer) → excluded ✓
  - Confirms the drive-by `install()`-target fix described under [How](#how).
- [x] **`npm link` (nested linked deps, two-level chain)**: published `nested-target@1.0.0` to Verdaccio. Created local `linked-widget` (registry-installs `nested-target`, declares `clientDependencies: ["nested-target"]`) and local `linked-builder` (declares `clientDependencies: ["linked-widget"]`). `npm link linked-widget` into `linked-builder`, then `npm link linked-builder` into `my-site` — the chain crosses two symlink boundaries. After `npx nudeps --init`:
  - BFS read declarations through both symlinks ✓
  - Import map: `linked-widget` → `./client_modules/linked-widget@1.0.0/index.js`, `nested-target` → `./client_modules/nested-target@1.0.0/index.js` ✓
  - `client_modules/linked-widget@1.0.0` → `../../linked-builder/node_modules/linked-widget` (1st symlink hop) ✓
  - `client_modules/nested-target@1.0.0` → `../../linked-widget/node_modules/nested-target` (target of the nested-linked widget — 2nd symlink hop) ✓
  - `linked-builder` (the symlinked declarer at top of chain) → excluded ✓
- [x] **Inconsistent declaration (devDep promoted by another devDep)**: synthetic project with `a` and `b` both in `devDependencies`; `b`'s `package.json` declares `clientDependencies: ["a"]`. After `npx nudeps --init`:
  - Warning emitted: `'a' is a devDependency but also promoted as a clientDependency by 'b'. Skipping — move 'a' to dependencies to expose it.` ✓
  - Import map empty (`map = {}`), `client_modules/` empty (no leftover from `a` or its transitive `leaf`) ✓
  - Build completes successfully — no throw, no `Cannot find "a" in lockfile` error ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #138
- <kbd>&nbsp;2&nbsp;</kbd> #136
- <kbd>&nbsp;1&nbsp;</kbd> #133 👈 
<!-- GitButler Footer Boundary Bottom -->