### PR TITLE
Document clientDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,18 +105,19 @@ For background, see these blog posts:
 	3. [Modes](#modes)
 	4. [Pruning (`nudeps --prune`)](#pruning-nudeps---prune)
 	5. [Force initialization (`nudeps --init`)](#force-initialization-nudeps---init)
-6. [Local dependencies (via `npm install ../other-repo`)](#local-dependencies-via-npm-install-other-repo)
+6. [Client dependencies (`clientDependencies`)](#client-dependencies-clientdependencies)
+7. [Local dependencies (via `npm install ../other-repo`)](#local-dependencies-via-npm-install-other-repo)
 	1. [Registration](#registration)
 	2. [Propagation](#propagation)
-7. [Programmatic API](#programmatic-api)
-8. [FAQ](#faq)
+8. [Programmatic API](#programmatic-api)
+9. [FAQ](#faq)
 	1. [Which browsers are supported?](#which-browsers-are-supported)
 	2. [Does this support pnpm/bun/yarn/etc.?](#does-this-support-pnpmbunyarnetc)
 	3. [Why does it add the version number to the directory name?](#why-does-it-add-the-version-number-to-the-directory-name)
 	4. [Do I need to add `.nudeps`, `client_modules` and `importmap.js` to my `.gitignore`?](#do-i-need-to-add-nudeps-client_modules-and-importmapjs-to-my-gitignore)
 	5. [Why doesn't Nudeps have an option to add integrity hashes to the import map?](#why-doesnt-nudeps-have-an-option-to-add-integrity-hashes-to-the-import-map)
 	6. [How are CJS (CommonJS) packages handled?](#how-are-cjs-commonjs-packages-handled)
-9. [Troubleshooting](#troubleshooting)
+10. [Troubleshooting](#troubleshooting)
 	1. [Getting an error about a specifier failing to resolve](#getting-an-error-about-a-specifier-failing-to-resolve)
 	2. [Package assumes a bundler is being used](#package-assumes-a-bundler-is-being-used)
 	3. [Packages that use extension-less paths](#packages-that-use-extension-less-paths)
@@ -397,6 +398,41 @@ You can set `prune: true` in your config file to always prune dependencies but t
 
 Force initialization, even if nudeps has already run.
 Note that this also clears the list of local dependents (see below). They will re-register the next time they run nudeps.
+
+## Client dependencies (`clientDependencies`)
+
+By default, Nudeps only processes production `dependencies` — `devDependencies` are excluded from the import map and not copied to `client_modules`.
+This is usually the right thing, since most dev dependencies (linters, test frameworks, build tools) have no business running in the browser.
+
+However, some dev dependencies — typically build tools — ship browser code that depends on other packages.
+A static site generator, for example, may emit components that `import` from a UI library.
+The consumer installs the generator as a `devDependency` and never imports the UI library directly, yet the UI library must still resolve in the browser.
+
+To make this work, a dev dependency declares which of *its own* dependencies should reach the consumer's import map via a `clientDependencies` field in *its own* `package.json`:
+
+```jsonc
+// site-builder/package.json — declared by the dev tool itself
+{
+  "name": "site-builder",
+  "dependencies": {
+    "widget-lib": "^1.0.0"
+  },
+  "clientDependencies": ["widget-lib"]
+}
+```
+
+Then any consumer that installs `site-builder` as a `devDependency` gets `widget-lib` in its import map automatically.
+**The consumer declares nothing** — installing `site-builder` is enough.
+
+Promoted dependencies behave identically to regular dependencies — they get an import map entry, are copied (or symlinked) to `client_modules`, get aliases, and (when installed locally) participate in change propagation.
+Their transitive production dependencies are included automatically.
+
+The syntax follows the same shape as [`bundledDependencies`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#bundledependencies) — an array of package names.
+Scoped packages (`@scope/pkg`) and [npm aliases](https://docs.npmjs.com/cli/v11/using-npm/package-spec#aliases) are supported.
+
+Nudeps only reads `clientDependencies` from dev dependencies. The field is silently ignored on regular runtime dependencies — they reach the import map already, so there's nothing to promote.
+
+If a promoted name is also listed in the consumer's `devDependencies`, the promotion is skipped with a warning — the consumer's own "dev-only" declaration wins. Move it to `dependencies` to expose it.
 
 ## Local dependencies (via `npm install ../other-repo`)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -20,6 +20,7 @@ Copies npm packages to a local output directory, generates an import map mapping
 | Hardcoding `client_modules/` or `importmap.js` paths            | These are configurable defaults (`dir` and `map` options). Read the project's nudeps config to determine actual paths                                                                           |
 | Specifier fails to resolve at runtime                           | Ensure entry points are declared in package.json, then run `npx nudeps`. See Troubleshooting in README.md (in the nudeps package directory)                                                     |
 | Using an unsupported package manager                            | Only npm is officially supported. nudeps reads `node_modules/.package-lock.json` which other package managers may not produce                                                                   |
+| Adding `clientDependencies` to the consumer's `package.json`    | `clientDependencies` is declared by a dev tool in *its own* `package.json` to expose deps to consumers. The consumer declares nothing — installing the tool is enough                          |
 
 ## Lifecycle
 
@@ -90,6 +91,25 @@ const { createElement } = require("react");
 ## Output
 
 nudeps logs a summary after each run: number of import map entries, time taken, and cache hits. If packages were copied or deleted, that's logged too. Warnings about CJS packages, missing lockfiles, or local dependencies appear inline — read them before proceeding.
+
+## Client Dependencies
+
+By default, nudeps excludes `devDependencies` from the import map. A dev dep that needs some of its own deps on the client declares them via a `clientDependencies` array in *its own* `package.json`:
+
+```jsonc
+// site-builder/package.json — declared by the dev tool
+{
+  "name": "site-builder",
+  "dependencies": { "widget-lib": "^1.0.0" },
+  "clientDependencies": ["widget-lib"]
+}
+```
+
+A consumer that installs `site-builder` as a devDep gets `widget-lib` in its import map automatically. The consumer declares nothing.
+
+Promoted deps behave identically to regular deps. Their transitive production dependencies are included automatically.
+
+If a promoted name is also listed in the consumer's `devDependencies`, the promotion is skipped with a warning — the consumer's own declaration wins. Fix: move the name to `dependencies`.
 
 ## Local Dependencies
 


### PR DESCRIPTION
Docs and AI skill updates for the `clientDependencies` field added in #133.

Stacked on top of #133 (code). Merge bottom-up.

- `README.md` — public API documentation
- `SKILL.md` — agent skill guidance

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #138
- <kbd>&nbsp;2&nbsp;</kbd> #136 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #133
<!-- GitButler Footer Boundary Bottom -->