### PR TITLE
Test cache invalidation on transitive upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 	"scripts": {
 		"release": "npm login && release-it",
 		"test": "npx htest ./test/index.js",
+		"test:regressions": "npx htest ./test/regressions/",
 		"demos": "cd ../nudeps-demos/ && ./each.sh 'npm link nudeps && npx nudeps'",
 		"init-demos": "cd ../nudeps-demos/ && ./each.sh 'npm link nudeps && npx nudeps --init'"
 	},

--- a/test/regressions/issue-132.js
+++ b/test/regressions/issue-132.js
@@ -1,0 +1,71 @@
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const NUDEPS_ROOT = resolve(import.meta.dirname, "../..");
+
+// Pull every colorjs.io URL from the generated importmap.js (matches imports and scopes).
+function getColorjsUrls (mapJs) {
+	return Array.from(mapJs.matchAll(/"colorjs\.io":\s*"([^"]+)"/g), m => m[1]);
+}
+
+export default {
+	name: "Cache replays stale resolution when transitive dep changes its entry point (issue #132)",
+	description:
+		"https://github.com/nudeps/nudeps/issues/132. Cached run replays the 0.5.2 entry " +
+		"point (dist/color.js); fresh run gives the actual 0.7.0 entry (src/index.js). " +
+		"Latent if 0.7.0-alpha.2 ever republishes with the same entry as 0.5.2 — re-pin then.",
+	async run () {
+		let tmpDir = mkdtempSync(join(tmpdir(), "nudeps-issue-132-"));
+		try {
+			let pkgPath = join(tmpDir, "package.json");
+			let mapPath = join(tmpDir, "importmap.js");
+
+			writeFileSync(
+				pkgPath,
+				JSON.stringify({
+					name: "issue-132-repro",
+					version: "1.0.0",
+					type: "module",
+					dependencies: {
+						"color-elements": "0.0.14",
+						nudeps: `file:${NUDEPS_ROOT}`,
+					},
+					overrides: { "colorjs.io": "0.5.2" },
+				}),
+			);
+
+			let env = { ...process.env, npm_config_audit: "false", npm_config_fund: "false" };
+			let exec = cmd => execSync(cmd, { cwd: tmpDir, env, stdio: "ignore" });
+
+			exec("npm install");
+
+			// Populate cache against colorjs.io@0.5.2
+			exec("npx nudeps");
+
+			// Upgrade colorjs.io. color-elements stays at 0.0.14 → its cache key is unchanged.
+			let pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+			pkg.overrides["colorjs.io"] = "0.7.0-alpha.2";
+			writeFileSync(pkgPath, JSON.stringify(pkg));
+			exec("npm install");
+
+			exec("npx nudeps");
+			let stale = getColorjsUrls(readFileSync(mapPath, "utf8"));
+
+			exec("npx nudeps --init");
+			let fresh = getColorjsUrls(readFileSync(mapPath, "utf8"));
+
+			return { stale, fresh };
+		}
+		finally {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	},
+	check ({ stale, fresh }) {
+		// Non-empty AND every URL across both runs collapses to a single value —
+		// catches internal inconsistency (imports vs scopes) and cross-run mismatch in one go.
+		return stale.length > 0 && fresh.length > 0 && new Set([...stale, ...fresh]).size === 1;
+	},
+	expect: true,
+};


### PR DESCRIPTION
Regression test for the cache bug fixed in #134.

Stacked on top of #134 — merge that first.

## Test plan

- [x] `test/regressions/issue-132.js` reproduces the bug end-to-end (npm install + override bump + diff cached vs `--init`). Fails without the fix (cached `dist/color.js` ≠ fresh `src/index.js`), passes with it.
- [x] `package.json` adds `test:regressions` script that auto-discovers everything in `test/regressions/`. The slow integration tests are excluded from the default suite.


<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #137 👈
- <kbd>&nbsp;1&nbsp;</kbd> #134
<!-- GitButler Footer Boundary Bottom -->
