### PR TITLE
Retain dev-flagged packages in the package index

### DIFF
--- a/src/util/packages.js
+++ b/src/util/packages.js
@@ -133,8 +133,10 @@ export default class Packages {
 		let rebase = p => (prefix ? prefix + "/" + p : "./" + p);
 
 		for (let [key, info] of Object.entries(raw)) {
-			if (!key || info.dev) {
-				continue;
+			// Keep dev-flagged entries: what gets deployed is gated by the import map, not the
+			// lockfile, so a package a consumer references should resolve regardless of its dev flag.
+			if (!key) {
+				continue; // Skip root entry
 			}
 
 			let resolved = info.link ? raw[info.resolved] : info;
@@ -166,7 +168,8 @@ export default class Packages {
 			let childRaw = children[pkg.resolvedPath]?.packages ?? {};
 
 			for (let [childKey, childInfo] of Object.entries(childRaw)) {
-				if (!childKey || childInfo.dev) {
+				// Dev-flagged entries are kept here too — see the root loop above.
+				if (!childKey) {
 					continue;
 				}
 

--- a/test/util/packages.js
+++ b/test/util/packages.js
@@ -9,6 +9,8 @@ let defaultData = {
 		"node_modules/foo/node_modules/bar": v,
 		"node_modules/foo/node_modules/@bar/baz": v,
 		"node_modules/@foo/bar/node_modules/@baz/quux": v,
+		// Hoisted but dev-flagged (e.g. a consumer's devDependency) — must still resolve
+		"node_modules/devlib": { version: "2.0.0", dev: true },
 	},
 };
 let defaultPackages = new Packages(defaultData);
@@ -215,8 +217,8 @@ let childLinkedDepsPackages = new Packages(
 	},
 );
 
-// Case I: dev-only entries (dev: true) in lockfiles should be filtered out
-// to prevent devDependencies from leaking into the package index.
+// Case I: dev-only entries (dev: true) in lockfiles are retained, so a package a consumer
+// references resolves regardless of its dev flag (deployment is gated by the map, not the lockfile).
 let childDevDepsPackages = new Packages(
 	{
 		packages: {
@@ -383,6 +385,15 @@ export default {
 				{ arg: "name", expect: "foo" },
 				{ arg: "filePath", expect: "@bar/" },
 				{ arg: "localPath", expect: "./client_modules/foo@1.2.3/@bar/" },
+			],
+		},
+		{
+			name: "./node_modules/devlib/index.js",
+			description: "Hoisted dev-flagged package resolves (deployment is gated by the map)",
+			tests: [
+				{ arg: "name", expect: "devlib" },
+				{ arg: "version", expect: "2.0.0" },
+				{ arg: "isExternal", expect: false },
 			],
 		},
 		// Case A: transitive dep via local dep's resolved path — flat top-level
@@ -582,7 +593,7 @@ export default {
 				{ arg: "localDir", expect: "./client_modules/leaf-dep@1.0.0" },
 			],
 		},
-		// Case I: dev-only entries in child lockfile should be filtered out.
+		// Case I: dev-flagged entries in a child lockfile are retained and resolve normally.
 		{
 			name: "./node_modules/ext-pkg/node_modules/prod-dep/index.js",
 			description: "Production dep from child lockfile is merged",
@@ -594,9 +605,12 @@ export default {
 		},
 		{
 			name: "./node_modules/ext-pkg/node_modules/dev-dep/index.js",
-			description: "Dev-only dep from child lockfile must not be merged",
+			description: "Dev-flagged dep from child lockfile is also merged",
 			packages: childDevDepsPackages,
-			tests: [{ arg: "pkg", expect: null }],
+			tests: [
+				{ arg: "name", expect: "dev-dep" },
+				{ arg: "version", expect: "2.0.0" },
+			],
 		},
 	],
 };


### PR DESCRIPTION
## What

Stop discarding `dev: true` entries when parsing the lockfile in `Packages`. Both the root-lockfile loop and the child-lockfile merge loop now retain dev-flagged packages.

## Why

`Packages` filtered out every `dev: true` lockfile entry, so a package **referenced in the generated import map** could not be resolved or copied if it was reachable only through a devDependency. `parse()` returned `pkg: null`, `localizeMap()` skipped queuing the copy, and the map ended up pointing at a path that was never written.

This blocks a real use case: a tool (e.g. a static-site generator) used as a host **devDependency** wants its own client libraries in the generated import map. npm flags everything in that subtree `dev: true` in the host lockfile, so those packages were invisible to nudeps even when explicitly referenced.

What gets deployed is gated by the **import map, not the lockfile** — unreferenced dev tooling never enters the map (and so is never copied) regardless of this filter. So filtering on the dev flag is the wrong layer. The filter was added speculatively in #118 (bundled with the #107 link-resolution fix), not to fix a concrete bug.

This is a prerequisite for letting a programmatic consumer inject extra packages into the map; the injection mechanism itself (likely via the existing hooks infrastructure) is a separate follow-up.

## Verification

- `npx htest ./test/index.js` → **139/139 pass**. Flipped the Case I test (dev-flagged child entry is now merged) and added a top-level hoisted-dev retention case.
- Regenerated all 13 **nudeps-demos** import maps with and without the filter (fresh `--init`, cache-free): **byte-identical, 0 diffs**. Every demo has `nudeps` as a devDependency, so its prod deps — including `cjs-browser-shim` and the CJS-shim lookup path — are exercised as dev-flagged. The change is provably inert for existing projects; it only matters when a dev-flagged package is actually referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
