### PR TITLE
Resolve install() targets from the lockfile; simplify cjs-browser-shim

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -72,9 +72,11 @@ export class ImportMapGenerator extends Generator {
 
 	async install (alias, target, { noRetry, ...installOptions } = {}) {
 		if (target === undefined) {
-			// Locate the dep in node_modules — at the monorepo root (prefix) under workspaces.
+			// The lockfile knows where the dep really lives (nested deps, workspace prefix); guess otherwise.
 			let prefix = this.nudeps?.packages.prefix ?? "";
-			target = `${prefix ? prefix + "/" : "./"}node_modules/${alias}`;
+			target =
+				this.nudeps?.packages.get(alias)?.path ??
+				`${prefix ? prefix + "/" : "./"}node_modules/${alias}`;
 		}
 
 		// Check if this install is cacheable:
@@ -200,19 +202,10 @@ export class ImportMapGenerator extends Generator {
 			return;
 		}
 
-		// Find cjs-browser-shim in the lockfile — prefer the user's own copy (shallowest).
-		// If not found, look for it under nudeps' own node_modules.
-		let { packages } = this.nudeps;
-		let shimPkg = packages.getAll("cjs-browser-shim")[0];
-		let shimPath = shimPkg?.path;
-		if (!shimPath) {
-			let nudepsPkg = packages.getAll("nudeps")[0];
-			shimPath = nudepsPkg
-				? nudepsPkg.path + "/node_modules/cjs-browser-shim"
-				: "./node_modules/cjs-browser-shim";
-		}
-		await this.install("cjs-browser-shim", shimPath, { noRetry: true });
+		// install() resolves the shim's path from the lockfile — it's nudeps' own dependency.
+		await this.install("cjs-browser-shim", undefined, { noRetry: true });
 
+		let { packages } = this.nudeps;
 		let cjsPackages = [...new Set(cjsEntries.map(([url]) => packages.parse(url).pkg?.name))];
 		// directDependencies (not just pkg.dependencies) so a CJS package injected via
 		// additionalDependencies is named in the require() hint too.


### PR DESCRIPTION
Closes #141.

## What

Two coupled changes in `src/map.js`:

1. **`install()` resolves an undefined target from the lockfile** — `Packages.get(alias)?.path` instead of the hardcoded `./node_modules/${alias}` guess. That's the source of truth for where each dep actually lives (workspace prefix, non-hoisted/nested locations included). Falls back to the old guess when the lockfile doesn't list it, so nothing regresses to a hard failure.

2. **`cjs-browser-shim` drops its bespoke path lookup.** It's nudeps' own *transitive dev* dependency, so — now that dev-flagged entries are retained (#139) — it's in `Packages` and resolves like any other injected package. The shim becomes a plain `install("cjs-browser-shim", undefined, { noRetry: true })`, deleting the `getAll` + `nudeps/node_modules` fallback dance. Same primitive as `additionalDependencies`.

## Credit

The target-from-`Packages` resolution is lifted from @DmitrySharabin's `install()` fix in #133 (it was a single squashed commit, so it's reproduced here with `Co-Authored-By` rather than cherry-picked).

## Verification

- `npx htest ./test/index.js` → **139/139**.
- `npm run test:e2e` → **2/2**.
- All 13 **nudeps-demos** regenerated with and without this change (cache-free `--init`): **byte-identical, 0 diffs** — including the CJS demos (interactjs/jquery/lodash/react/underscore) that exercise the shim path. `get("cjs-browser-shim").path` resolves to exactly what the old `getAll`+fallback produced, with no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
