### PR TITLE
Fix root-package fallback being wiped by the cjs-browser-shim install (#144)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,6 @@ export default async function (options) {
 	}
 
 	await nudeps.installAll();
-	await nudeps.finalize();
 
 	let dirExists = existsSync(config.dir);
 	if (config.init && dirExists) {

--- a/src/nudeps.js
+++ b/src/nudeps.js
@@ -125,11 +125,15 @@ export default class Nudeps {
 		}
 		this.stats.resolveTime = performance.now() - resolveStart;
 
-		// If root package installation failed due to missing dependencies in the entry point,
-		// add it manually after all dependencies are installed using JSPM's resolver.
-		// We do this AFTER dependency installation because generator.install() regenerates the
-		// import map, which would overwrite any mappings added earlier.
-		// See https://github.com/nudeps/nudeps/issues/30
+		// Finalize (CJS shim install + cache pruning) before the root-mapping fallback below.
+		// The shim step is itself an install(), and every install() rebuilds JSPM's map and drops
+		// manually-set entries — so the fallback has to be the last thing that touches the map.
+		await this.finalize();
+
+		// If the root install failed because the entry point imports a package that isn't installed,
+		// JSPM never maps the root package to its own entry point. Resolve the entry point ourselves
+		// and pin it — last, so finalize()'s shim install can't wipe it.
+		// See https://github.com/nudeps/nudeps/issues/30 and https://github.com/nudeps/nudeps/issues/144
 		// Note: string prefix match on JSPM error message — may need updating if JSPM changes it.
 		if (rootInstallError?.message.startsWith("Cannot find package")) {
 			try {

--- a/test/e2e/issue-30.js
+++ b/test/e2e/issue-30.js
@@ -1,24 +1,21 @@
 import { execSync } from "node:child_process";
-import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 const NUDEPS_ROOT = resolve(import.meta.dirname, "../..");
 
-// https://github.com/nudeps/nudeps/issues/30. When the root entry point imports a package that
-// isn't in node_modules, JSPM's root install fails with "Cannot find package …" and nudeps falls
-// back to resolving the entry point manually (Nudeps.installAll). That fallback lives in nudeps.js
-// but depends on node:url helpers that used to be imported only in index.js — a regression that
-// left the fallback throwing a ReferenceError inside its try/catch, surfacing only as a stray
-// "Failed to manually resolve …" log. This test forces the fallback (index.js imports a package
-// that is never installed) and asserts it both runs (root install fails) and completes cleanly.
-//
-// NOTE: it deliberately does NOT assert the root self-reference lands in the map. That outcome is
-// currently masked by a separate, pre-existing bug — finalize()'s cjs-browser-shim install runs an
-// install() after the fallback, which discards the manually-set entry. Strengthen this assertion
-// once that is fixed (see the issue tracking the shim-wipe).
+// https://github.com/nudeps/nudeps/issues/30 + https://github.com/nudeps/nudeps/issues/144.
+// When the root entry point imports a package that isn't installed, JSPM's root install fails with
+// "Cannot find package …" and never maps the root package to its own entry point. nudeps recovers
+// by resolving the entry point itself and pinning it (Nudeps.installAll). Two regressions this
+// guards: (a) the fallback's node:url imports going missing → it throws and pins nothing (#30 path);
+// (b) the pin being applied before finalize()'s cjs-browser-shim install, which rebuilds the map
+// and wipes it (#144). This repro forces the fallback (index.js imports a never-installed package)
+// under the default CJS handling — so the shim install runs — and asserts the root self-reference
+// still lands in the map.
 export default {
-	name: "Root-package fallback runs cleanly when the entry point imports a missing package (issue #30)",
+	name: "Root package is mapped to its entry point when the entry imports a missing package (issue #30, #144)",
 	async run () {
 		let tmpDir = mkdtempSync(join(tmpdir(), "nudeps-issue-30-"));
 		try {
@@ -37,20 +34,20 @@ export default {
 			writeFileSync(join(tmpDir, "index.js"), `import "this-package-is-not-installed";\n`);
 
 			let env = { ...process.env, npm_config_audit: "false", npm_config_fund: "false" };
-			let exec = cmd => execSync(cmd, { cwd: tmpDir, env, encoding: "utf8" });
+			let exec = cmd => execSync(cmd, { cwd: tmpDir, env, stdio: "ignore" });
 
 			exec("npm install");
-			// Merge stderr so we see nudeps' error() logs; nudeps exits 0 even when the root install fails.
-			return exec("npx nudeps 2>&1");
+			exec("npx nudeps");
+
+			let map = readFileSync(join(tmpDir, "importmap.js"), "utf8");
+			return map.match(/"issue-30-repro":\s*"([^"]+)"/)?.[1] ?? null;
 		}
 		finally {
 			rmSync(tmpDir, { recursive: true, force: true });
 		}
 	},
-	// The root install must fail (proving we reached the fallback) AND the manual resolution must
-	// not error (proving its imports resolve). A dropped node:url import trips the second clause.
-	check: out =>
-		out.includes("Failed to install root package") &&
-		!out.includes("Failed to manually resolve root package entry point"),
+	// The root package must map to its own entry point — proving the fallback ran and survived
+	// finalize()'s shim install.
+	check: entry => typeof entry === "string" && entry.includes("index.js"),
 	expect: true,
 };


### PR DESCRIPTION
Fixes #144.

## Problem

The #30 fallback maps the root package to its own entry point (when JSPM can't trace it because the entry imports a package that isn't installed) via `generator.map.set()` in `Nudeps.installAll()`. But **any `generator.install()` rebuilds JSPM's internal map and drops manually-set entries**, and `finalize()`'s `cjs-browser-shim` install runs *after* the fallback — so the pin was wiped whenever a shim was added. The fallback only took effect under `--cjs=false`.

## Fix

Call `finalize()` from inside `installAll()`, *before* the fallback, so the manual pin is the last mutation to the map and survives. `index.js` no longer calls `finalize()` separately.

## Verification

- Repro (entry imports a missing package, default CJS): the root self-reference `"<pkg>": "./index.js"` now lands in the map; previously absent.
- `test/e2e/issue-30.js` strengthened to assert the root entry is present (it ran under default CJS so the shim install happens). Full `test/e2e/` 3/3 and the unit suite pass.
- Regenerating the `underscore` demo reports "Import map unchanged" vs. `main` — normal projects (fallback not triggered) produce byte-identical output.

Pre-existing bug — not introduced by the `installAll()` extraction; it predates it.
