### PR TITLE
Add host adapter system with publishDir option (closes #147)

### DIFF
--- a/src/hosts.js
+++ b/src/hosts.js
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-export const netlify = {
+export const netlify = ({ publishDir } = {}) => ({
 	name: "Netlify",
 	detect: () => process.env.NETLIFY === "true",
 	symlinks: false,
@@ -13,23 +13,24 @@ export const netlify = {
 				return;
 			}
 
-			// Netlify doesn't support symlinks, add _rewrites
-			// In a workspace child, prefix paths with the child dir and write to root
-			// e.g. /child/client_modules/foo/* /child/client_modules/foo@1.0.0/:splat 302
-			let { prefix } = this.packages;
-			let pathPrefix = prefix ? path.relative(path.resolve(prefix), process.cwd()) + "/" : "";
+			// No publishDir → fall back to the workspace prefix (cwd → lockfile root): in npm workspaces the lockfile root is typically the deploy root
+			let pathPrefix = publishDir ?? this.packages.prefix;
 
 			let redirects = aliasEntries
 				.map(
 					([aliasPath, target]) =>
-						`/${pathPrefix}${aliasPath}/* /${pathPrefix}${path.join(path.dirname(aliasPath), target)}/:splat 302`,
+						`/${path.relative(pathPrefix, aliasPath)}/* /${path.relative(pathPrefix, path.join(path.dirname(aliasPath), target))}/:splat 302`,
 				)
 				.join("\n");
 
-			fs.appendFileSync(path.join(prefix, "_redirects"), `${redirects}\n`);
+			fs.appendFileSync(path.join(pathPrefix, "_redirects"), `${redirects}\n`);
+
+			this.info(
+				`${this.host.name} host: _redirects written to ${path.resolve(pathPrefix, "_redirects")}`,
+			);
 		},
 	},
-};
+});
 
 export const vercel = {
 	name: "Vercel",
@@ -39,11 +40,11 @@ export const vercel = {
 };
 
 // same file, same syntax
-export const cloudflare = {
-	...netlify,
+export const cloudflare = ({ publishDir } = {}) => ({
+	...netlify({ publishDir }),
 	name: "Cloudflare",
 	detect: () => process.env.CLOUDFLARE_PAGES === "true",
-};
+});
 
 export const apache = ({ publishDir, file = ".htaccess" } = {}) => ({
 	name: "Apache",

--- a/src/nudeps.js
+++ b/src/nudeps.js
@@ -53,25 +53,29 @@ export default class Nudeps {
 			);
 		}
 
-		if (this.config.host) {
-			this.host = hosts[this.config.host];
-			if (!this.host) {
+		let resolve = host =>
+			typeof host === "function" ? host({ publishDir: this.config.publishDir }) : host;
+
+		let host = this.config.host;
+		if (typeof host === "string") {
+			host = hosts[host];
+			if (!host) {
 				this.warn(`Unknown host: ${this.config.host}`);
 			}
 		}
-		else {
+		else if (!host) {
 			// Auto-detect host
 			for (let hostId in hosts) {
-				let host = hosts[hostId];
-				if (host.detect?.()) {
-					this.host = host;
+				let candidate = resolve(hosts[hostId]);
+				if (candidate.detect?.()) {
+					host = candidate;
 					this.info(`Detected host: ${host.name}`);
 					break;
 				}
 			}
 		}
 
-		this.host ??= {};
+		this.host = resolve(host) ?? {};
 
 		if (this.host.hooks) {
 			this.hooks.add(this.host.hooks);

--- a/src/options.js
+++ b/src/options.js
@@ -69,6 +69,19 @@ export const hooks = {
 	cli: false,
 };
 
+export const host = {
+	cli: false,
+	validate: v =>
+		(typeof v === "string" && v) ||
+		typeof v === "function" ||
+		(typeof v === "object" && v !== null && !Array.isArray(v)),
+};
+
+export const publishDir = {
+	cli: false,
+	validate: v => typeof v === "string" && v,
+};
+
 export const module = {
 	default: false,
 };


### PR DESCRIPTION
## Summary
Resolves #147. Adds a programmatic `host` config option, a top-level `publishDir` option, and converts `netlify`/`cloudflare` to factories that take `{publishDir}` so the `create-aliases-end` hook can:
- write `_redirects` inside the publish dir (was: cwd)
- emit publish-relative rule paths (was: `/dist/`-prefixed)
- log where the file landed via `this.info`

## Behavior
- `host` accepts string (key lookup), function (factory invoked with `{publishDir}`), or object (pre-built host). Invalid types silently drop via the standard `validate` mechanic, falling back to auto-detect.
- `publishDir` accepts a non-empty string. When unset, `pathPrefix` falls back to `this.packages.prefix` so npm-workspace topology still works.
- Existing `appendFileSync` semantics preserved (no marker-block yet; see #99).

## Test plan
- [x] Smoke: docspire docs build with `NETLIFY=true` — `Detected host: Netlify`, 2 publish-relative rules, file at `_site/_redirects`.
- [x] Workspace child topology — minimal demo (root + `child/` workspace with `lit`, `NETLIFY=true npx nudeps` from `child/`): `_redirects` written to the workspace root with publish-relative rules prefixed by `/child/`, e.g. `/child/client_modules/lit/* /child/client_modules/lit@3.3.3/:splat 302`.
- [x] `npm test` 143/143 PASS; `npm run test:e2e` 4/4 PASS — no regressions.

## Known gaps (separate issues)
- Vercel and gitHubPages remain plain objects (no `publishDir` integration yet).
- Append never truncates — stale rules accumulate (`#99` marker-block design covers this).
- If `config.dir` lives outside `publishDir`, `path.relative` produces `../`-rules without warning.