### PR TITLE
Config schema v2: conditional overrides + pipeline hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ That's it. Now `npm install vue` and `import { createApp } from "vue"` just work
 - [Getting Started](https://nudeps.dev/start/)
 - [How It Works](https://nudeps.dev/how-it-works/) — including how Nudeps compares to JSPM
 - [CLI](https://nudeps.dev/cli/)
-- [Configuration](https://nudeps.dev/config/) — [deployed files](https://nudeps.dev/config/files/), [aliases](https://nudeps.dev/config/aliases/), [modes](https://nudeps.dev/config/modes/)
+- [Configuration](https://nudeps.dev/config/) — [deployed files](https://nudeps.dev/config/files/), [aliases](https://nudeps.dev/config/aliases/), [overrides & modes](https://nudeps.dev/config/overrides/)
 - [Local Dependencies](https://nudeps.dev/local-deps/)
 - [Programmatic API](https://nudeps.dev/api/)
 - [FAQ](https://nudeps.dev/faq/) · [Troubleshooting](https://nudeps.dev/troubleshooting/)

--- a/SKILL.md
+++ b/SKILL.md
@@ -56,21 +56,64 @@ import { someFunction } from "some-package";
 
 ## Config (default: `nudeps.js`, configurable via `--config`)
 
-Config file uses ES module syntax: `export default { ... }`.
+Config file uses ES module syntax: `export default { ... }`. Unknown or invalid options throw with a pointed error (typos get a suggestion; pre-rename options name their replacement).
 
-| Option                   | Default            | Description                                                                                                                                                                                                     |
-| ------------------------ | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dir`                    | `"client_modules"` | Output directory for copied packages                                                                                                                                                                            |
-| `map`                    | `"importmap.js"`   | Import map injection script path                                                                                                                                                                                |
-| `publishDir`             | Workspace root     | Directory the host serves as `/`. Set it when `dir` lives inside a build output directory (e.g. an SSG's `dist/`), so hosts that need redirects write them there with correct URLs                              |
-| `mode`                   | —                  | Preset: `"dev"` (symlink) or `"prod"` (prune + terse)                                                                                                                                                           |
-| `exclude`                | `[]`               | Packages to omit from import map (e.g., server-only deps)                                                                                                                                                       |
-| `additionalDependencies` | `[]`               | Extra packages to add beyond `dependencies` — e.g. a tool calling nudeps programmatically injecting its own client libraries. Treated like `dependencies`; no-op if already in `dependencies`                   |
-| `forceDependencies`      | `[]`               | Like `additionalDependencies`, but kept even when `prune` is on — use for packages you always want in the map regardless of what entry points reference. Subject to `exclude` (both → excluded, with a warning) |
-| `cjs`                    | `true`             | Include CJS shim for CommonJS packages                                                                                                                                                                          |
-| `prune`                  | `false`            | Subset import map to only used specifiers                                                                                                                                                                       |
-| `alias`                  | `true`             | Unversioned symlinks for stable asset URLs (CSS, images). Use the unversioned path in HTML/CSS (e.g., `<link href="[output-dir]/open-props/style.css">`)                                                        |
-| `hooks`                  | —                  | Object of lifecycle hook callbacks (e.g., `constructed`, `create-aliases-start`). See [blissful-hooks](https://github.com/LeaVerou/blissful-hooks)                                                              |
+| Option             | Default            | Description                                                                                                                                                                                          |
+| ------------------ | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dir`              | `"client_modules"` | Output directory for copied packages. Per-package overridable                                                                                                                                        |
+| `map`              | `"importmap.js"`   | Import map injection script path                                                                                                                                                                     |
+| `root`             | Workspace root     | Directory the host serves as `/`. Set it when `dir` lives inside a build output directory (e.g. an SSG's `dist/`), so hosts that need redirects write them there with correct URLs                   |
+| `host`             | Auto-detected      | Deploy host adapter: `"netlify"`, `"vercel"`, `"cloudflare"`, `"gitHubPages"`                                                                                                                        |
+| `mode`             | —                  | Active mode, tested by rules with `mode` matchers. Built-in presets: `"dev"` (symlink) and `"prod"` (no symlink + prune + terse)                                                                     |
+| `prune`            | `false`            | Subset import map to specifiers the entry points use, plus `include: "force"` packages                                                                                                               |
+| `terse`            | `false`            | Lightly minify the map script                                                                                                                                                                        |
+| `module`           | `false`            | Emit the map script for `type="module"` loading (reduces browser support)                                                                                                                            |
+| `cjs`              | `true`             | Include CJS shim for CommonJS packages. Per-package overridable                                                                                                                                      |
+| `subpaths`         | `"split"`          | `"split"` keeps every used subpath mapping explicit; `"combined"` collapses within scopes; `"both"` also collapses top-level                                                                         |
+| `symlink`          | External pkgs only | Symlink packages into `dir` instead of copying                                                                                                                                                       |
+| `preserveSymlinks` | `false`            | Keep symlinks inside a copied package instead of resolving them                                                                                                                                      |
+| `alias`            | `true`             | Unversioned symlink per package for stable asset URLs (CSS, images): `<link href="[dir]/open-props/style.css">`. A string is a custom path relative to the package's `dir` (may escape it: `"../x"`) |
+| `imports`          | —                  | Import map entries merged into the generated map (`{ specifier: path }`, path relative to the map file; `undefined` deletes). In a package rule, paths are package-relative                          |
+| `ignore`           | Readmes, dotfiles… | File globs (package-relative) to skip when copying. Entries: `"glob"`, `{ ignore: glob }`, or `{ copy: glob }` (reverses earlier ignores, including the defaults). Last match wins                   |
+| `overrides`        | —                  | Conditional config rules — see below                                                                                                                                                                 |
+| `hooks`            | —                  | Object of lifecycle hook callbacks (`constructed`, `create-aliases-start`, `create-aliases-after-external`, `create-aliases-end`). See [blissful-hooks](https://github.com/LeaVerou/blissful-hooks)  |
+
+### Conditional overrides
+
+One mechanism for per-package settings, mode presets, and combinations. Dictionary form for the common case (each key is one exact name or install name):
+
+```js
+export default {
+	overrides: {
+		"open-props": { alias: "../open-props" }, // stable URL at project root
+		"canvas-confetti": { include: true }, // install beyond package.json deps (prunable)
+		vue: { include: "force" }, // install AND survive prune
+		"@netlify/blobs": { include: false }, // server-only: keep out of direct installs
+		"legacy-lib": { cjs: false },
+	},
+};
+```
+
+Array form for patterns, versions, and modes — matchers are exact strings (semver ranges for `version`), regexes, predicates, or any-of arrays; multiple matcher fields AND together; a rule with no matchers is unconditional:
+
+```js
+export default {
+	overrides: [
+		{ mode: "staging", terse: false }, // mode preset (custom modes are just rules)
+		{ installName: /^@types\//, include: false },
+		{ name: "leaflet", version: "^1", ignore: "docs/**" },
+		{ mode: "prod", name: "leaflet", symlink: false }, // package × mode
+		{ name: "vue", imports: { vue: "./dist/vue.esm-browser.prod.js" } },
+	],
+};
+```
+
+Semantics agents must know:
+
+- **Cascade**: all matching rules apply in order, later wins, merged per property. Origin order: option defaults < built-in mode rules < top-level config < user rules < CLI/programmatic args. Rule layers concatenate (a tool's programmatic rules compose with the config file's).
+- **`include: false` does not guarantee absence** — the package still lands in the map if code actively imports it.
+- `include: true`/`"force"` need exact-name matchers (you can't install a regex); `include: false` accepts patterns.
+- Package-matched rules may only set package-scoped options (`dir`, `symlink`, `preserveSymlinks`, `alias`, `ignore`, `imports`, `cjs`, `include`); mode-only/unconditional rules may set anything.
 
 Full option reference: https://nudeps.dev/config/ · Troubleshooting: https://nudeps.dev/troubleshooting/
 
@@ -101,7 +144,7 @@ nudeps logs a summary after each run: number of import map entries, time taken, 
 
 ## npm Workspaces
 
-Running nudeps inside a workspace package works: it finds the lockfile at the monorepo root (deps are hoisted there), so hoisted dependencies and sibling workspace packages both resolve — hoisted deps get copied, siblings get symlinked into the package's output dir. `npx nudeps install` in a workspace child automatically adds `dependencies` and `prepare` hooks to the workspace root that delegate to children (`npm run <hook> --if-present --workspaces`), so `npm install` at the root triggers import map generation in each child. On Netlify (and Cloudflare), workspace children write redirect rules to the **root** `_redirects` with the child directory as a path prefix — no per-child `_redirects` is created. This assumes the workspace root is the deploy root; if it isn't, set `publishDir`. Limitation: change propagation between sibling workspace packages is not wired up.
+Running nudeps inside a workspace package works: it finds the lockfile at the monorepo root (deps are hoisted there), so hoisted dependencies and sibling workspace packages both resolve — hoisted deps get copied, siblings get symlinked into the package's output dir. `npx nudeps install` in a workspace child automatically adds `dependencies` and `prepare` hooks to the workspace root that delegate to children (`npm run <hook> --if-present --workspaces`), so `npm install` at the root triggers import map generation in each child. On Netlify (and Cloudflare), workspace children write redirect rules to the **root** `_redirects` with the child directory as a path prefix — no per-child `_redirects` is created. This assumes the workspace root is the deploy root; if it isn't, set `root`. Limitation: change propagation between sibling workspace packages is not wired up.
 
 ## Programmatic API
 
@@ -117,7 +160,7 @@ Returns the `Nudeps` instance, whose `config` holds the resolved options (`dir`,
 Pass `defaults` to suggest values the user's own config still wins over — useful when a tool (e.g. an SSG) wants its own paths unless the project says otherwise:
 
 ```js
-await nudeps({ defaults: { dir: "dist/client_modules", publishDir: "dist" } });
+await nudeps({ defaults: { dir: "dist/client_modules", root: "dist" } });
 ```
 
 ## Generated Artifacts — Do Not Edit

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"@jspm/overrides": "^1.0.0",
 		"blissful-hooks": "^0.0.2",
 		"cjs-browser-shim": "latest",
-		"minimist": "^1.2.8"
+		"minimist": "^1.2.8",
+		"sver": "^2.0.1"
 	}
 }

--- a/src/cli/args.js
+++ b/src/cli/args.js
@@ -1,16 +1,24 @@
 /**
  * Parse CLI arguments into nudeps option overrides.
  * Reads process.argv by default; accepts a custom argv array for testing.
+ * Only coerces values by declared type; validation happens in getConfig, which throws loudly.
  */
 import minimist from "minimist";
 import * as availableOptions from "../options.js";
+import { coerce } from "../util/options.js";
 
 export default function readArgs (argv = process.argv.slice(2)) {
 	let args = minimist(argv);
 	let ret = {};
+	let known = new Set(["_"]);
 
 	for (let key in availableOptions) {
 		let option = availableOptions[key];
+		known.add(key);
+		if (option.flag) {
+			known.add(option.flag);
+		}
+
 		if (option.cli === false) {
 			continue;
 		}
@@ -18,7 +26,7 @@ export default function readArgs (argv = process.argv.slice(2)) {
 		if (key in args) {
 			ret[key] = args[key];
 		}
-		else if (option.flag in args) {
+		else if (option.flag && option.flag in args) {
 			ret[key] = args[option.flag];
 		}
 		else {
@@ -28,15 +36,14 @@ export default function readArgs (argv = process.argv.slice(2)) {
 		if (typeof ret[key] === "string" && option.parse) {
 			ret[key] = option.parse(ret[key]);
 		}
-		else if (
-			typeof option.default === "boolean" &&
-			(ret[key] === "true" || ret[key] === "false")
-		) {
-			ret[key] = ret[key] === "true";
+		else {
+			ret[key] = coerce(ret[key], option.type);
 		}
+	}
 
-		if (option.validate && !option.validate(ret[key])) {
-			delete ret[key];
+	for (let key in args) {
+		if (!known.has(key)) {
+			console.warn(`[nudeps] Ignoring unknown CLI flag --${key}`);
 		}
 	}
 

--- a/src/config.js
+++ b/src/config.js
@@ -6,14 +6,28 @@ import { importCwdRelative } from "./util.js";
 import { existsSync } from "node:fs";
 import * as availableOptions from "./options.js";
 import { checkType, suggest } from "./util/options.js";
-import builtInModes from "./modes.js";
-
-// Config-file keys that are valid but not option descriptors
-const NON_OPTION_KEYS = new Set(["modes"]);
+import {
+	builtInRules,
+	builtInModes,
+	normalizeRules,
+	validateRules,
+	isPackageRule,
+	applyRules,
+} from "./rules.js";
 
 /**
  * @import { NudepsOptions } from "./options.js"
  */
+
+// Keys from previous versions, mapped to what replaced them
+const RENAMED = {
+	exclude: `overrides rules with include: false, e.g. overrides: [{ name: "foo", include: false }]`,
+	additionalDependencies: `overrides rules with include: true`,
+	forceDependencies: `overrides rules with include: "force"`,
+	combineSubpaths: `subpaths: "split" | "combined" | "both"`,
+	publishDir: `root`,
+	modes: `overrides rules with mode matchers, e.g. overrides: [{ mode: "staging", terse: false }]`,
+};
 
 function readExternalConfig (args, defaults = {}) {
 	// A path from `defaults` is only a suggestion, so a missing file falls back to no config
@@ -31,54 +45,11 @@ function readExternalConfig (args, defaults = {}) {
 }
 
 /**
- * Recursively resolve a mode's option defaults by following its `mode` (parent) key.
- * Child values override parent values. When a cycle is detected (e.g. a custom mode
- * extending a same-named built-in like `prod: { mode: "prod", ... }`), falls back
- * to resolving the parent from built-in modes before giving up.
- * @param {string} name - Mode name to resolve
- * @param {object} allModes - All available modes (built-in + custom)
- * @param {object} [options]
- * @param {object} [options.baseModes] - Fallback modes for cycle resolution (defaults to built-in modes)
- * @param {Set} [options.seen] - Tracks visited modes for cycle detection
- * @returns {object} Merged defaults for this mode chain
- */
-export function resolveDefaults (
-	name,
-	allModes,
-	{ baseModes = builtInModes, seen = new Set() } = {},
-) {
-	if (name === undefined) {
-		return {};
-	}
-
-	if (!(name in allModes)) {
-		let available = Object.keys(allModes).join(", ");
-		console.warn(`Unknown mode "${name}". Available modes: ${available}`);
-		return {};
-	}
-
-	if (seen.has(name)) {
-		// Cycle — fall back to built-in modes if available (supports
-		// custom modes extending same-named built-ins, e.g. prod: { mode: "prod", ... })
-		if (baseModes && name in baseModes) {
-			return resolveDefaults(name, baseModes, { baseModes: null, seen: new Set() });
-		}
-
-		console.warn(`Circular mode reference detected: ${name}`);
-		return {};
-	}
-
-	seen.add(name);
-
-	let { mode: parent, ...ownDefaults } = allModes[name];
-	let parentDefaults = resolveDefaults(parent, allModes, { baseModes, seen });
-
-	return { ...parentDefaults, ...ownDefaults };
-}
-
-/**
- * Get the resolved config regardless of where settings come from
- * @param {NudepsOptions} [overrides] - Options taking precedence over the config file and mode defaults,
+ * Get the resolved config regardless of where settings come from.
+ * Precedence (weakest to strongest): option defaults < `defaults` < built-in rules <
+ * top-level config file values < matching user rules < programmatic/CLI args.
+ * Package-matched rules are not folded here; Nudeps resolves them per package.
+ * @param {NudepsOptions} [overrides] - Options taking precedence over the config file and rules,
  * except `defaults`, which is only consulted when nothing else supplies a value.
  * @returns {NudepsOptions} Every option, normalized, with defaults applied.
  */
@@ -89,29 +60,66 @@ export async function getConfig ({ defaults = {}, ...args } = {}) {
 		config = await config;
 	}
 
-	// Unknown config file keys are almost always typos — fail loudly with a suggestion
-	for (let key in config) {
-		if (!(key in availableOptions) && !NON_OPTION_KEYS.has(key)) {
-			let suggestion = suggest(key, Object.keys(availableOptions));
-			let hint = suggestion ? ` Did you mean "${suggestion}"?` : "";
-			throw new Error(`Unknown config option "${key}".${hint}`);
+	// Unknown keys are almost always typos (or pre-rename options) — fail loudly,
+	// for programmatic callers and the config file alike
+	for (let [keys, from] of [
+		[Object.keys(config), "config file"],
+		[Object.keys(args), "options"],
+		[Object.keys(defaults), "defaults"],
+	]) {
+		for (let key of keys) {
+			if (key in RENAMED) {
+				throw new Error(
+					`The "${key}" option (from ${from}) was replaced by ${RENAMED[key]}.`,
+				);
+			}
+
+			if (!(key in availableOptions)) {
+				let suggestion = suggest(key, Object.keys(availableOptions));
+				let hint = suggestion ? ` Did you mean "${suggestion}"?` : "";
+				throw new Error(`Unknown option "${key}" (from ${from}).${hint}`);
+			}
 		}
 	}
 
-	// Resolve mode and its defaults
 	let mode = args.mode ?? config.mode ?? defaults.mode;
-	let customModes = config.modes ?? {};
-	let allModes = { ...builtInModes, ...customModes };
-	let modeDefaults = resolveDefaults(mode, allModes);
+
+	// Overrides resolve first: global (mode-only/unconditional) rules feed the other options.
+	// Layers concatenate rather than replace — rules are a cascade, and a tool passing rules
+	// programmatically must not clobber the config file's own — ordered weakest-origin first.
+	for (let rawRules of [defaults.overrides, config.overrides, args.overrides]) {
+		if (rawRules && looksLikeImportMap(rawRules)) {
+			throw new Error(
+				`The "overrides" option now holds conditional config rules; import map patches moved to "imports".`,
+			);
+		}
+	}
+
+	let rules = [defaults.overrides, config.overrides, args.overrides].flatMap(normalizeRules);
+	validateRules(rules);
+	warnOnUnknownMode(mode, rules);
+
+	let subject = { mode };
+	let globalRules = rules.filter(rule => !isPackageRule(rule));
+	let fromBuiltIns = applyRules({}, builtInRules, subject);
+	let fromRules = applyRules({}, globalRules, subject);
 
 	let ret = {};
 	for (let key in availableOptions) {
 		let option = availableOptions[key];
+
+		if (key === "overrides") {
+			// Already normalized; kept whole (incl. package rules) for Nudeps and the cache key
+			ret.overrides = rules;
+			continue;
+		}
+
 		// Track where the value came from so validation errors can point at the culprit
 		let sources = [
 			[args[key], "options"],
+			[fromRules[key], "overrides"],
 			[config[key], "config file"],
-			[modeDefaults[key], `mode "${mode}"`],
+			[fromBuiltIns[key], `mode "${mode}"`],
 			[defaults[key], "defaults"],
 		];
 		let [value, source] = sources.find(([v]) => v !== undefined) ?? [];
@@ -137,4 +145,47 @@ export async function getConfig ({ defaults = {}, ...args } = {}) {
 	}
 
 	return ret;
+}
+
+/**
+ * The old map-merge overrides shape ({imports, scopes}) now belongs to `imports` —
+ * catch it so migrating configs get a pointed error rather than rule validation noise.
+ */
+function looksLikeImportMap (value) {
+	return (
+		typeof value === "object" &&
+		!Array.isArray(value) &&
+		("imports" in value || "scopes" in value) &&
+		Object.values(value).every(v => typeof v === "object")
+	);
+}
+
+/**
+ * Modes are no longer declared anywhere, so the best we can do for a typo'd active mode
+ * is check that some rule (or built-in) could match it. Patterns can't be enumerated —
+ * any regex/function mode matcher disables the check.
+ */
+function warnOnUnknownMode (mode, rules) {
+	if (mode === undefined || builtInModes.has(mode)) {
+		return;
+	}
+
+	let known = new Set();
+	for (let rule of rules) {
+		if (rule.mode === undefined) {
+			continue;
+		}
+
+		for (let matcher of [rule.mode].flat()) {
+			if (typeof matcher !== "string") {
+				return; // Pattern — can't tell, stay quiet
+			}
+			known.add(matcher);
+		}
+	}
+
+	if (!known.has(mode)) {
+		let available = [...builtInModes, ...known].join(", ");
+		console.warn(`Unknown mode "${mode}". Modes referenced by rules: ${available}`);
+	}
 }

--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,11 @@
 import { importCwdRelative } from "./util.js";
 import { existsSync } from "node:fs";
 import * as availableOptions from "./options.js";
+import { checkType, suggest } from "./util/options.js";
 import builtInModes from "./modes.js";
+
+// Config-file keys that are valid but not option descriptors
+const NON_OPTION_KEYS = new Set(["modes"]);
 
 /**
  * @import { NudepsOptions } from "./options.js"
@@ -85,6 +89,15 @@ export async function getConfig ({ defaults = {}, ...args } = {}) {
 		config = await config;
 	}
 
+	// Unknown config file keys are almost always typos — fail loudly with a suggestion
+	for (let key in config) {
+		if (!(key in availableOptions) && !NON_OPTION_KEYS.has(key)) {
+			let suggestion = suggest(key, Object.keys(availableOptions));
+			let hint = suggestion ? ` Did you mean "${suggestion}"?` : "";
+			throw new Error(`Unknown config option "${key}".${hint}`);
+		}
+	}
+
 	// Resolve mode and its defaults
 	let mode = args.mode ?? config.mode ?? defaults.mode;
 	let customModes = config.modes ?? {};
@@ -94,20 +107,33 @@ export async function getConfig ({ defaults = {}, ...args } = {}) {
 	let ret = {};
 	for (let key in availableOptions) {
 		let option = availableOptions[key];
-		ret[key] = args[key] ?? config[key] ?? modeDefaults[key] ?? defaults[key];
+		// Track where the value came from so validation errors can point at the culprit
+		let sources = [
+			[args[key], "options"],
+			[config[key], "config file"],
+			[modeDefaults[key], `mode "${mode}"`],
+			[defaults[key], "defaults"],
+		];
+		let [value, source] = sources.find(([v]) => v !== undefined) ?? [];
 
-		if (ret[key] !== undefined) {
-			if (option.validate && !option.validate(ret[key])) {
-				delete ret[key];
+		if (value !== undefined) {
+			let typeOk = checkType(value, option.type);
+			if (!typeOk || (option.validate && !option.validate(value))) {
+				let expected = typeOk ? "" : ` Expected ${[option.type].flat().join(" or ")}.`;
+				throw new Error(
+					`Invalid value for option "${key}" (from ${source}): ${JSON.stringify(value) ?? value}.${expected}`,
+				);
 			}
 		}
 
 		if (option.normalize) {
-			ret[key] = option.normalize(ret[key], option.default);
+			value = option.normalize(value, option.default);
 		}
 		else {
-			ret[key] ??= option.default;
+			value ??= option.default;
 		}
+
+		ret[key] = value;
 	}
 
 	return ret;

--- a/src/hosts.js
+++ b/src/hosts.js
@@ -16,12 +16,12 @@ export const netlify = {
 			// Netlify doesn't support symlinks, so aliases become redirect rules.
 			// Rules match URLs, so both the file and the paths in it are relative to the publish dir,
 			// e.g. /child/client_modules/foo/* /child/client_modules/foo@1.0.0/:splat 302
-			let { publishDir } = this;
-			let url = p => "/" + path.relative(publishDir, p);
+			let { root } = this;
+			let url = p => "/" + path.relative(root, p);
 
 			if (url(this.dir).startsWith("/..")) {
 				this.warn(
-					`${this.dir} is outside the publish directory (${publishDir || "."}), so its redirect rules cannot match any URL. Set the publishDir option.`,
+					`${this.dir} is outside the web root (${root || "."}), so its redirect rules cannot match any URL. Set the root option.`,
 				);
 			}
 
@@ -32,9 +32,9 @@ export const netlify = {
 				)
 				.join("\n");
 
-			let file = path.join(publishDir, "_redirects");
+			let file = path.join(root, "_redirects");
 			// The publish dir may not exist yet: nudeps can run before the build that fills it
-			fs.mkdirSync(path.resolve(publishDir), { recursive: true });
+			fs.mkdirSync(path.resolve(root), { recursive: true });
 			fs.appendFileSync(file, `${redirects}\n`);
 			this.info(`Wrote ${aliasEntries.length} alias redirects to ${file}`);
 		},
@@ -55,7 +55,7 @@ export const cloudflare = {
 	detect: () => process.env.CLOUDFLARE_PAGES === "true",
 };
 
-export const apache = ({ publishDir, file = ".htaccess" } = {}) => ({
+export const apache = ({ root, file = ".htaccess" } = {}) => ({
 	name: "Apache",
 	symlinks: true, // TODO detect FollowSymLinks
 	redirects: true,

--- a/src/index.js
+++ b/src/index.js
@@ -74,14 +74,13 @@ export default async function (options) {
 	// Rewrite the import map to point at local copies, then materialize those copies in config.dir
 	nudeps.localizeMap();
 
-	// Seed aliased deps the map walk missed (CSS-only packages — #102)
-	if (config.alias) {
-		for (let dep of nudeps.directDependencies) {
-			let pkg = nudeps.packages.get(dep);
+	// Seed aliased deps the map walk missed (CSS-only packages — #102).
+	// aliases() consults per-package rules, so no global gate here.
+	for (let dep of nudeps.directDependencies) {
+		let pkg = nudeps.packages.get(dep);
 
-			if (pkg && !pkg.parent && nudeps.aliases(pkg).length > 0) {
-				nudeps.toCopy[pkg.path] ??= nudeps.localDir(pkg);
-			}
+		if (pkg && !pkg.parent && nudeps.aliases(pkg).length > 0) {
+			nudeps.toCopy[pkg.path] ??= nudeps.localDir(pkg);
 		}
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,8 @@
 import * as path from "node:path";
 import { getConfig } from "./config.js";
 import { readFileSync, writeFileSync, renameSync, existsSync, mkdirSync, rmSync } from "node:fs";
-import { writeJSONSync, createGitignoredDir } from "./util.js";
+import { createGitignoredDir } from "./util.js";
+import { stringifyConfig } from "./util/options.js";
 import Nudeps from "./nudeps.js";
 
 /**
@@ -104,7 +105,8 @@ export default async function (options) {
 		writeFileSync(config.map, mapContent);
 	}
 
-	writeJSONSync(".nudeps/config.json", config);
+	// stringifyConfig keeps function values as source text so the cache compare sees them
+	writeFileSync(".nudeps/config.json", stringifyConfig(config) + "\n");
 
 	let info = [];
 	if (stats.copied + stats.deleted + stats.aliased > 0) {

--- a/src/map.js
+++ b/src/map.js
@@ -18,12 +18,7 @@ export class ImportMapGenerator extends Generator {
 	 * @param {Nudeps} [options.nudeps] - Nudeps instance for lock data access
 	 * @param {boolean} [options.silent] - Suppress user-facing log messages (for internal temp generators)
 	 */
-	constructor ({ mode, installCache, silent, nudeps, ...generatorOptions } = {}) {
-		if (mode) {
-			this.mode = mode;
-			generatorOptions.env ??= [mode, "browser", "module"];
-		}
-
+	constructor ({ installCache, silent, nudeps, ...generatorOptions } = {}) {
 		let commonJS = generatorOptions.commonJS ?? true;
 
 		super({
@@ -49,7 +44,7 @@ export class ImportMapGenerator extends Generator {
 		// installCache and silent are intentionally excluded from _options: installCache so that
 		// temp generators always have null caches (preventing recursion); silent so that
 		// sub-generators created on cache miss still produce user-facing log messages.
-		this._options = { mode, nudeps, ...generatorOptions };
+		this._options = { nudeps, ...generatorOptions };
 
 		// Patch package configs before JSPM resolves them:
 		// 1. Apply community overrides (client-side equivalent of what jspm.io CDN does server-side)

--- a/src/modes.js
+++ b/src/modes.js
@@ -1,8 +1,0 @@
-/**
- * Built-in mode presets that package up multiple option defaults.
- * `dev` optimizes for local development; `prod` optimizes for deployment.
- */
-export default {
-	dev: { symlink: true },
-	prod: { symlink: false, prune: true, terse: true },
-};

--- a/src/nudeps.js
+++ b/src/nudeps.js
@@ -13,6 +13,7 @@ import { readJSONSync, writeJSONSync, createGitignoredDir } from "./util.js";
 import { ImportMapGenerator, ImportMap } from "./map.js";
 import { matchesGlob, ensureSymlink } from "./util/fs.js";
 import { stringifyConfig } from "./util/options.js";
+import { applyRules, isPackageRule, includeNames } from "./rules.js";
 import { getTopLevelModules } from "./util.js";
 import Packages from "./util/packages.js";
 import * as hosts from "./hosts.js";
@@ -21,6 +22,7 @@ import nudepsPkg from "../package.json" with { type: "json" };
 
 /**
  * @import Package from "./util/package.js"
+ * @import { NudepsOptions } from "./options.js"
  */
 
 export default class Nudeps {
@@ -43,16 +45,6 @@ export default class Nudeps {
 	constructor ({ config }) {
 		this.config = config;
 		this.oldConfig = readJSONSync(".nudeps/config.json", { optional: true });
-
-		// Warn on contradictory config: a package both forced and excluded. exclude wins (forced
-		// names are filtered out of directDependencies), so the force entry would silently do nothing.
-		let excluded = new Set(this.config.exclude ?? []);
-		let forcedAndExcluded = this.config.forceDependencies.filter(name => excluded.has(name));
-		if (forcedAndExcluded.length > 0) {
-			this.warn(
-				`Ignoring forceDependencies also listed in exclude (exclude wins): ${forcedAndExcluded.join(", ")}`,
-			);
-		}
 
 		if (this.config.host) {
 			// Adapters may be factories taking the config (e.g. apache)
@@ -95,8 +87,6 @@ export default class Nudeps {
 		}
 
 		this.toDelete = new Set(this.existingDirs);
-		this.hasIgnoreExceptions = this.config.ignore.some(p => p.include);
-		this.hasDeepGlobs = this.config.ignore.some(p => (p.include ?? p.exclude)?.includes("/"));
 
 		if (this.config.hooks) {
 			this.hooks.add(this.config.hooks);
@@ -123,10 +113,9 @@ export default class Nudeps {
 			var rootInstallError = e;
 		}
 
-		// forceDependencies install even when pruning; the rest of directDependencies only when not.
-		let forced = new Set(this.config.forceDependencies);
+		// include: "force" packages install even when pruning; the rest of directDependencies only when not.
 		let toInstall = this.config.prune
-			? this.directDependencies.filter(name => forced.has(name))
+			? this.directDependencies.filter(name => this.include(name) === "force")
 			: this.directDependencies;
 
 		for (const dep of toInstall) {
@@ -294,22 +283,72 @@ export default class Nudeps {
 		return value;
 	}
 
+	// Rules that constrain which packages they apply to; resolved per package by pkgConfig()
+	get packageRules () {
+		let value = (this.config.overrides ?? []).filter(isPackageRule);
+		Object.defineProperty(this, "packageRules", { value, configurable: true });
+		return value;
+	}
+
+	#pkgConfigs = new Map();
+
+	/**
+	 * The effective config for one package: the global config plus every matching
+	 * package rule, applied in order (later wins, per property; `ignore` appends).
+	 * @param {Package} pkg
+	 * @returns {NudepsOptions}
+	 */
+	pkgConfig (pkg) {
+		let value = this.#pkgConfigs.get(pkg);
+
+		if (!value) {
+			value = applyRules(this.config, this.packageRules, {
+				name: pkg.name,
+				installName: pkg.installName,
+				version: pkg.version,
+				mode: this.config.mode,
+			});
+			this.#pkgConfigs.set(pkg, value);
+		}
+
+		return value;
+	}
+
+	/**
+	 * The effective `include` setting for a bare specifier, before its Package
+	 * necessarily exists (rules can add packages that aren't installed yet).
+	 * @param {string} name
+	 * @returns {boolean | "force" | undefined}
+	 */
+	include (name) {
+		let pkg = this.packages.get(name);
+		return applyRules({}, this.packageRules, {
+			name: pkg?.name ?? name,
+			installName: pkg?.installName ?? name,
+			version: pkg?.version,
+			mode: this.config.mode,
+		}).include;
+	}
+
 	/**
 	 * The specifiers nudeps installs directly (beyond what the root trace pulls in): the host's
-	 * production `dependencies` plus any `additionalDependencies` and `forceDependencies`, minus
-	 * `exclude`d ones. Deduped, so an entry already in `dependencies` is a no-op. This is the full
-	 * (non-pruned) set; `prune` is applied by `installAll`, which installs only the
-	 * `forceDependencies` subset — not here.
+	 * production `dependencies` plus packages rules add (`include: true` / `"force"`), minus
+	 * dropped ones (`include: false`). This is the full (non-pruned) set; `prune` is applied
+	 * by `installAll`, which installs only the `include: "force"` subset — not here.
 	 * @returns {string[]}
 	 */
 	get directDependencies () {
-		let exclude = new Set(this.config.exclude ?? []);
-		let names = new Set([
-			...Object.keys(this.pkg.dependencies ?? {}),
-			...this.config.additionalDependencies,
-			...this.config.forceDependencies,
-		]);
-		return [...names].filter(name => !exclude.has(name));
+		let names = new Set(Object.keys(this.pkg.dependencies ?? {}));
+
+		for (let rule of this.packageRules) {
+			if (rule.include === true || rule.include === "force") {
+				for (let name of includeNames(rule)) {
+					names.add(name);
+				}
+			}
+		}
+
+		return [...names].filter(name => this.include(name) !== false);
 	}
 
 	get packages () {
@@ -321,7 +360,8 @@ export default class Nudeps {
 	get generator () {
 		let generatorOptions = {
 			commonJS: this.config.cjs,
-			combineSubpaths: this.config.combineSubpaths,
+			// The subpaths enum maps onto @jspm/generator's combineSubpaths tri-state
+			combineSubpaths: { split: false, combined: true, both: "both" }[this.config.subpaths],
 			installCache: this.installCache,
 			nudeps: this,
 		};
@@ -335,8 +375,8 @@ export default class Nudeps {
 		let value = new ImportMap(this.generator);
 		value.cleanupScopes();
 
-		if (this.config.overrides) {
-			value.applyOverrides(this.config.overrides);
+		if (this.config.imports) {
+			value.applyOverrides({ imports: this.config.imports });
 		}
 
 		Object.defineProperty(this, "map", { value, configurable: true });
@@ -350,10 +390,10 @@ export default class Nudeps {
 	/**
 	 * The directory served as `/`, which host adapters need to turn file paths into URLs.
 	 * Defaults to the workspace root, which in npm workspaces is typically the deploy root.
-	 * @returns {string} Path relative to cwd (`""` when cwd is itself the publish dir)
+	 * @returns {string} Path relative to cwd (`""` when cwd is itself the web root)
 	 */
-	get publishDir () {
-		return this.config.publishDir ?? this.packages.prefix;
+	get root () {
+		return this.config.root ?? this.packages.prefix;
 	}
 
 	get elapsedTime () {
@@ -373,8 +413,8 @@ export default class Nudeps {
 	}
 
 	/**
-	 * Compute the client_modules output directory for a package.
-	 * All packages go to top-level client_modules.
+	 * Compute the output directory for a package: its effective `dir`
+	 * (rules can relocate individual packages) plus the versioned dir name.
 	 * @param {Package} pkg
 	 * @returns {string}
 	 */
@@ -383,7 +423,7 @@ export default class Nudeps {
 			return this.dir;
 		}
 
-		return [this.dir, pkg.dirName].join("/");
+		return path.normalize([this.pkgConfig(pkg).dir, pkg.dirName].join("/"));
 	}
 
 	/**
@@ -484,12 +524,13 @@ export default class Nudeps {
 	}
 
 	/**
-	 * Resolve alias config into alias paths for a package.
+	 * Resolve a package's effective alias setting into alias paths.
 	 * @param {Package} pkg
-	 * @param {*} [alias] - Alias config; defaults to this.config.alias
 	 * @returns {string[]}
 	 */
-	aliases (pkg, alias = this.config.alias) {
+	aliases (pkg) {
+		let alias = this.pkgConfig(pkg).alias;
+
 		if (!alias) {
 			return [];
 		}
@@ -500,56 +541,26 @@ export default class Nudeps {
 			return root?.version !== pkg.version ? [] : [pkg.installName];
 		}
 
-		if (Array.isArray(alias)) {
-			return alias.flatMap(item => this.aliases(pkg, item));
-		}
-
-		if (typeof alias === "string") {
-			return pkg.name === alias || pkg.installName === alias ? [alias] : [];
-		}
-
-		// Object form: resolve to value via key lookup, then fall through
-		if (typeof alias === "object") {
-			alias = alias[pkg.installName] ?? alias[pkg.name];
-		}
-
-		// Function form (top-level or object value)
-		if (typeof alias === "function") {
-			alias = alias(pkg);
-		}
-
-		return alias == null ? [] : [alias].flat();
+		return [alias].flat();
 	}
 
 	/**
 	 * Whether symlinks should be dereferenced (resolved to real paths) when copying a package.
-	 * @param {string} packageName
-	 * @param {string} version
+	 * @param {Package} pkg
 	 * @returns {boolean}
 	 */
-	dereference (packageName, version) {
-		switch (typeof this.config.preserveSymlinks) {
-			case "boolean":
-				return !this.config.preserveSymlinks;
-			case "function":
-				return !this.config.preserveSymlinks({ packageName, version });
-		}
-
-		if (Array.isArray(this.config.preserveSymlinks)) {
-			// Array of package names
-			return !this.config.preserveSymlinks.includes(packageName);
-		}
-
-		return true;
+	dereference (pkg) {
+		return !this.pkgConfig(pkg).preserveSymlinks;
 	}
 
 	shouldSymlink (pkg) {
-		let { symlink } = this.config;
+		let { symlink } = this.pkgConfig(pkg);
 
 		if (typeof symlink === "boolean") {
 			return symlink;
 		}
 
+		// The built-in default: external packages are symlinked
 		return symlink(pkg);
 	}
 
@@ -558,21 +569,16 @@ export default class Nudeps {
 			return false;
 		}
 
-		let packageName = pkg?.name;
+		let ignore = pkg ? this.pkgConfig(pkg).ignore : this.config.ignore;
 
 		// If we traverse backwards we can stop once we find a pattern that would change the inclusion status
-		for (let i = this.config.ignore.length - 1; i >= 0; i--) {
-			let p = this.config.ignore[i];
-
-			if (p.packageName && !p.packageName.includes(packageName)) {
-				continue;
-			}
-
-			let glob = p.exclude ?? p.include;
+		for (let i = ignore.length - 1; i >= 0; i--) {
+			let p = ignore[i];
+			let glob = p.ignore ?? p.copy;
 			let matches = matchesGlob(filePath, glob);
 
 			if (matches) {
-				if (!p.exclude) {
+				if (!p.ignore) {
 					return false;
 				}
 
@@ -636,6 +642,38 @@ export default class Nudeps {
 				delete map.scopes[scope];
 			}
 		}
+
+		// Rule-scoped imports: keys are the matched package's own specifiers, values are
+		// package-relative paths — resolved against the package's localized directory.
+		// NOTE: emitted as global imports; a rule matching several packages overwrites per spec.
+		for (let rule of this.packageRules) {
+			if (!rule.imports) {
+				continue;
+			}
+
+			for (let pkg of packages) {
+				if (this.pkgConfig(pkg).imports !== rule.imports) {
+					continue;
+				}
+
+				for (let [specifier, target] of Object.entries(rule.imports)) {
+					if (target === undefined) {
+						delete map.imports?.[specifier];
+						continue;
+					}
+
+					let urlFromMap = path.relative(mapDir, this.localPath(pkg, target));
+					urlFromMap = urlFromMap.startsWith(".") ? urlFromMap : "./" + urlFromMap;
+					if (specifier.endsWith("/") && !urlFromMap.endsWith("/")) {
+						// Preserve directory specifiers that require a trailing slash in import maps
+						urlFromMap += "/";
+					}
+					map.imports ??= {};
+					map.imports[specifier] = urlFromMap;
+					toCopy[pkg.path] ??= this.localDir(pkg);
+				}
+			}
+		}
 	}
 
 	async copyPackages () {
@@ -681,11 +719,11 @@ export default class Nudeps {
 			}
 			else {
 				stats.copied++;
-				if (this.config.ignore.some(p => p.exclude)) {
+				if (this.pkgConfig(pkg).ignore.some(p => p.ignore)) {
 					pkg.exportedPaths = await this.getExportedPaths(pkg);
 				}
 				cpSync(from, to, {
-					dereference: this.dereference(pkg.name, pkg.version),
+					dereference: this.dereference(pkg),
 					preserveTimestamps: true,
 					recursive: true,
 					filter: src => {
@@ -706,19 +744,18 @@ export default class Nudeps {
 				});
 			}
 
-			// Create alias symlinks (unversioned paths pointing to versioned directories)
-			if (config.alias) {
-				for (let alias of this.aliases(pkg)) {
-					let aliasPath = path.normalize(config.dir + "/" + alias);
-					let relTarget = path.relative(path.dirname(aliasPath), to);
-					let exists = existingDirs.has(aliasPath);
+			// Create alias symlinks (unversioned paths pointing to versioned directories).
+			// Alias paths are relative to the package's effective dir, so they can escape it.
+			for (let alias of this.aliases(pkg)) {
+				let aliasPath = path.normalize(this.pkgConfig(pkg).dir + "/" + alias);
+				let relTarget = path.relative(path.dirname(aliasPath), to);
+				let exists = existingDirs.has(aliasPath);
 
-					if (exists) {
-						toDelete.delete(aliasPath);
-					}
-
-					this.toAlias[aliasPath] = relTarget;
+				if (exists) {
+					toDelete.delete(aliasPath);
 				}
+
+				this.toAlias[aliasPath] = relTarget;
 			}
 		}
 

--- a/src/nudeps.js
+++ b/src/nudeps.js
@@ -12,6 +12,7 @@ import Hooks from "blissful-hooks";
 import { readJSONSync, writeJSONSync, createGitignoredDir } from "./util.js";
 import { ImportMapGenerator, ImportMap } from "./map.js";
 import { matchesGlob, ensureSymlink } from "./util/fs.js";
+import { stringifyConfig } from "./util/options.js";
 import { getTopLevelModules } from "./util.js";
 import Packages from "./util/packages.js";
 import * as hosts from "./hosts.js";
@@ -54,10 +55,9 @@ export default class Nudeps {
 		}
 
 		if (this.config.host) {
-			this.host = hosts[this.config.host];
-			if (!this.host) {
-				this.warn(`Unknown host: ${this.config.host}`);
-			}
+			// Adapters may be factories taking the config (e.g. apache)
+			let adapter = hosts[this.config.host];
+			this.host = typeof adapter === "function" ? adapter(this.config) : adapter;
 		}
 		else {
 			// Auto-detect host
@@ -170,7 +170,9 @@ export default class Nudeps {
 	}
 
 	get installCache () {
-		let configChanged = JSON.stringify(this.oldConfig) !== JSON.stringify(this.config);
+		// stringifyConfig keeps function/regex values as source text, so editing e.g. a
+		// symlink callback or hooks in the config file correctly busts the cache
+		let configChanged = stringifyConfig(this.oldConfig) !== stringifyConfig(this.config);
 		let cacheData = readJSONSync(".nudeps/cache.json", { optional: true });
 		if (cacheData?.version !== nudepsPkg.version || configChanged) {
 			cacheData = null;

--- a/src/options.js
+++ b/src/options.js
@@ -1,5 +1,5 @@
-import { existsSync } from "node:fs";
 import * as path from "node:path";
+import * as hosts from "./hosts.js";
 
 /**
  * @import Package from "./util/package.js"
@@ -22,12 +22,13 @@ import * as path from "node:path";
  * @property {string} [map="importmap.js"] - Path of the generated import map script.
  * @property {string} [publishDir] - Directory the host serves as `/`, defaults to the package (or workspace) root.
  * Only needed when `dir` lives inside a build output directory (e.g. an SSG's `dist/`), since redirect rules are URLs, not file paths.
+ * @property {string} [host] - Deploy host adapter (a key of `hosts.js`, e.g. `"netlify"`). Auto-detected from the environment when not set.
  * @property {string} [mode] - Mode preset to take defaults from: built-in `"dev"` or `"prod"`, or a key of `modes`.
  * @property {Record<string, NudepsOptions>} [modes] - Custom mode presets, keyed by name.
  * Each can extend another by setting its own `mode`. Config file only.
  * @property {string} [config="nudeps.js"] - Path of the config file to read. Ignored if the file does not exist.
  * @property {boolean} [init=false] - Start from scratch: delete the `.nudeps` cache and `dir` before generating.
- * @property {string[]} [exclude=[]] - Dependency names to keep out of the import map entirely (e.g. server-only deps).
+ * @property {string | string[]} [exclude=[]] - Dependency names to keep out of the import map entirely (e.g. server-only deps).
  * @property {string | string[]} [additionalDependencies=[]] - Extra packages to map beyond the host's `dependencies`,
  * e.g. client libraries injected by a tool calling nudeps programmatically. Treated like `dependencies`.
  * @property {string | string[]} [forceDependencies=[]] - Like `additionalDependencies`, but kept even when `prune` is on.
@@ -52,28 +53,33 @@ import * as path from "node:path";
 
 export const dir = {
 	flag: "d",
+	type: "string",
 	default: "./client_modules",
 	normalize: (v, defaultValue) => path.normalize(v ?? defaultValue),
 };
 
 export const mode = {
 	flag: "m",
-	cli: true,
+	type: "string",
 };
 
 export const map = {
 	flag: "o",
+	type: "string",
 	default: "importmap.js",
 };
 
 export const terse = {
+	type: "boolean",
 	default: false,
 };
 
 export const exclude = {
 	flag: "e",
+	type: ["string", "list"],
 	parse: v => v.split(","),
 	default: [],
+	normalize: (v, defaultValue) => (v == null ? defaultValue : [v].flat()),
 };
 
 // Extra packages to add to the import map beyond the host's `dependencies` — e.g. a tool
@@ -82,6 +88,7 @@ export const exclude = {
 // `exclude`); a no-op for anything already in `dependencies`.
 export const additionalDependencies = {
 	cli: false,
+	type: ["string", "list"],
 	default: [],
 	normalize: (v, defaultValue) => (v == null ? defaultValue : [v].flat()),
 };
@@ -91,54 +98,65 @@ export const additionalDependencies = {
 // the entry points reference them. Subject to `exclude` (a name in both is excluded, with a warning).
 export const forceDependencies = {
 	cli: false,
+	type: ["string", "list"],
 	default: [],
 	normalize: (v, defaultValue) => (v == null ? defaultValue : [v].flat()),
 };
 
 export const prune = {
+	type: "boolean",
 	default: false,
 };
 
+// A missing explicitly-passed path throws in readExternalConfig; a path from
+// `defaults` is only a suggestion, so no existence validation here.
 export const config = {
 	flag: "c",
+	type: "string",
 	default: "nudeps.js",
-	validate: v => existsSync(v),
-	file: false,
 };
 
 export const init = {
+	type: "boolean",
 	default: false,
 };
 
 export const overrides = {
 	cli: false,
+	type: "object",
 };
 
 export const hooks = {
 	cli: false,
+	type: "object",
 };
 
 // The directory the host serves as `/`. Only needed when `dir` lives inside a build output
 // directory (e.g. an SSG's `dist/`), since redirect rules are URLs, not file paths.
 export const publishDir = {
 	flag: "publish-dir",
-	validate: v => typeof v === "string",
+	type: "string",
 };
 
 export const module = {
+	type: "boolean",
 	default: false,
 };
 
 export const cjs = {
+	type: "boolean",
 	default: true,
 };
 
 export const combineSubpaths = {
 	flag: "combine-subpaths",
+	type: ["boolean", "string"],
 	default: false,
+	validate: v => typeof v === "boolean" || v === "both",
 };
 
 export const ignore = {
+	type: ["string", "object", "list"],
 	default: [
 		// Readme files with any extension
 		"{readme,README}.*",
@@ -174,13 +192,22 @@ export const ignore = {
 };
 
 export const symlink = {
+	type: ["boolean", "function"],
 	default: pkg => pkg.isExternal,
 };
 
 export const preserveSymlinks = {
+	type: ["boolean", "list", "function"],
 	default: false,
 };
 
 export const alias = {
+	type: ["boolean", "string", "list", "object", "function"],
 	default: true,
+};
+
+// Deploy host adapter; auto-detected from the environment when not set.
+export const host = {
+	type: "string",
+	validate: v => v in hosts,
 };

--- a/src/options.js
+++ b/src/options.js
@@ -6,48 +6,74 @@ import * as hosts from "./hosts.js";
  */
 
 /**
- * A file pattern in `ignore`. A bare string is shorthand for `{ exclude: pattern }`.
+ * A file pattern in `ignore`. A bare string is shorthand for `{ ignore: pattern }`.
  * Later patterns win over earlier ones.
  * @typedef {object} IgnorePattern
- * @property {string} [exclude] - Glob of files to skip when copying a package.
- * @property {string} [include] - Glob of files to keep, overriding earlier `exclude` patterns.
- * @property {string | string[]} [packageName] - Only apply this pattern to these packages.
+ * @property {string} [ignore] - Glob of files to skip when copying a package.
+ * @property {string} [copy] - Glob of files to keep, overriding earlier `ignore` patterns.
+ */
+
+/**
+ * A matcher for one field of an override rule: an exact string (a semver range for `version`),
+ * a regex, a predicate on the field's value, or an array of these (any-of).
+ * @typedef {string | RegExp | ((value: string) => boolean) | Array<string | RegExp | ((value: string) => boolean)>} Matcher
+ */
+
+/**
+ * A conditional config override: matcher fields (`name`, `installName`, `version`, `mode`)
+ * select which packages and/or modes the rule applies to (all present must match;
+ * none = unconditional), and the remaining keys are option values to override.
+ * Package-matched rules may set only package-scoped options (`dir`, `symlink`,
+ * `preserveSymlinks`, `alias`, `ignore`, `imports`, `cjs`) plus `include`;
+ * mode-only and unconditional rules may set any option.
+ * @typedef {object} OverrideRule
+ * @property {Matcher} [name] - Package name to match.
+ * @property {Matcher} [installName] - Install name (the key in `dependencies`) to match.
+ * @property {Matcher} [version] - Package version to match (string = semver range).
+ * @property {Matcher} [mode] - Active mode to match.
+ * @property {boolean | "force"} [include] - Membership in the direct-install set:
+ * `true` installs the package like a dependency even if unlisted (prunable),
+ * `"force"` also survives `prune`, `false` removes it from direct installs
+ * (it still gets mapped if something imports it). `undefined` = standard behavior.
  */
 
 /**
  * Every nudeps option, as accepted from programmatic args, the `nudeps.js` config file,
- * a mode preset, or CLI flags (in that order of precedence).
+ * override rules, or CLI flags.
  * @typedef {object} NudepsOptions
  * @property {string} [dir="./client_modules"] - Directory to copy (or symlink) client-side dependencies into.
  * @property {string} [map="importmap.js"] - Path of the generated import map script.
- * @property {string} [publishDir] - Directory the host serves as `/`, defaults to the package (or workspace) root.
+ * @property {string} [root] - Directory the host serves as `/`, defaults to the package (or workspace) root.
  * Only needed when `dir` lives inside a build output directory (e.g. an SSG's `dist/`), since redirect rules are URLs, not file paths.
  * @property {string} [host] - Deploy host adapter (a key of `hosts.js`, e.g. `"netlify"`). Auto-detected from the environment when not set.
- * @property {string} [mode] - Mode preset to take defaults from: built-in `"dev"` or `"prod"`, or a key of `modes`.
- * @property {Record<string, NudepsOptions>} [modes] - Custom mode presets, keyed by name.
- * Each can extend another by setting its own `mode`. Config file only.
+ * @property {string} [mode] - Active mode, tested by rules with `mode` matchers. Built-in presets: `"dev"` and `"prod"`.
  * @property {string} [config="nudeps.js"] - Path of the config file to read. Ignored if the file does not exist.
  * @property {boolean} [init=false] - Start from scratch: delete the `.nudeps` cache and `dir` before generating.
- * @property {string | string[]} [exclude=[]] - Dependency names to keep out of the import map entirely (e.g. server-only deps).
- * @property {string | string[]} [additionalDependencies=[]] - Extra packages to map beyond the host's `dependencies`,
- * e.g. client libraries injected by a tool calling nudeps programmatically. Treated like `dependencies`.
- * @property {string | string[]} [forceDependencies=[]] - Like `additionalDependencies`, but kept even when `prune` is on.
- * Subject to `exclude`: a name in both is excluded, with a warning.
- * @property {boolean} [prune=false] - Subset the import map to only the specifiers the entry points actually use.
+ * @property {boolean} [prune=false] - Subset the import map to only the specifiers the entry points actually use
+ * (plus `include: "force"` packages).
  * @property {boolean} [terse=false] - Lightly minify the generated import map script.
  * @property {boolean} [module=false] - Whether the import map script will be loaded as `type="module"`.
  * @property {boolean} [cjs=true] - Add `cjs-browser-shim` when CommonJS packages are detected.
- * @property {boolean} [combineSubpaths=false] - Collapse a package's subpath mappings into a single trailing-slash mapping where possible.
+ * @property {"split" | "combined" | "both"} [subpaths="split"] - Whether to collapse a package's subpath mappings
+ * into a single trailing-slash mapping: `"split"` keeps every used subpath explicit, `"combined"` collapses
+ * within scopes, `"both"` also collapses top-level.
  * @property {boolean | ((pkg: Package) => boolean)} [symlink] - Whether to symlink a package instead of copying it.
  * Defaults to symlinking only external packages (those outside the local `node_modules` tree).
- * @property {boolean | string[] | ((pkg: {packageName: string, version: string}) => boolean)} [preserveSymlinks=false] - Whether to keep symlinks inside a copied package as-is instead of resolving them to real paths.
- * @property {boolean | string | string[] | Record<string, any> | ((pkg: Package) => string | string[])} [alias=true] - Unversioned symlinks pointing at the versioned directories, so assets (CSS, images) have stable URLs.
- * `true` aliases every package, a string or array aliases those names, an object maps package names to aliases, a function computes them.
- * @property {object} [overrides] - Partial import map (`imports`, `scopes`) deep-merged into the generated one.
- * @property {Array<string | IgnorePattern>} [ignore] - Files to skip when copying packages.
- * Adds to the defaults (readmes, dotfiles, package and lockfiles) rather than replacing them.
+ * @property {boolean} [preserveSymlinks=false] - Whether to keep symlinks inside a copied package as-is instead of resolving them to real paths.
+ * @property {boolean | string} [alias=true] - Unversioned symlink pointing at a package's versioned directory,
+ * so assets (CSS, images) have stable URLs. `true` uses the install name; a string is a custom path relative to
+ * the package's effective `dir` (and may escape it, e.g. `"../open-props"`).
+ * @property {Record<string, string | undefined>} [imports] - Import map entries deep-merged into the generated
+ * map's `imports`; values are paths relative to the map or full URLs, and `undefined` deletes an entry.
+ * Inside a package-matched rule, values are paths relative to that package instead.
+ * @property {Array<string | IgnorePattern>} [ignore] - Files to skip when copying packages; globs are
+ * package-relative. Adds to the defaults (readmes, dotfiles, package and lockfiles) rather than replacing them —
+ * a later `{ copy }` pattern reverses an earlier ignore, including the defaults.
+ * @property {Record<string, Omit<OverrideRule, "name" | "installName">> | OverrideRule[]} [overrides] - Conditional
+ * config overrides. The dictionary form keys are single exact names (matched against name or install name);
+ * the array form gives full rules. All matching rules apply in order, later wins, merged per property.
  * @property {Record<string, Function | Function[]>} [hooks] - Lifecycle hook callbacks, see [blissful-hooks](https://github.com/LeaVerou/blissful-hooks).
- * @property {NudepsOptions} [defaults] - Fallbacks for anything the config file and mode preset leave unset,
+ * @property {NudepsOptions} [defaults] - Fallbacks for anything the config file and rules leave unset,
  * so a tool running nudeps programmatically can suggest values without overriding the user's own config. Programmatic API only.
  */
 
@@ -74,35 +100,6 @@ export const terse = {
 	default: false,
 };
 
-export const exclude = {
-	flag: "e",
-	type: ["string", "list"],
-	parse: v => v.split(","),
-	default: [],
-	normalize: (v, defaultValue) => (v == null ? defaultValue : [v].flat()),
-};
-
-// Extra packages to add to the import map beyond the host's `dependencies` — e.g. a tool
-// (static site generator, etc.) calling nudeps programmatically can inject its own client
-// libraries. Treated exactly like `dependencies` (installed unless pruned, subject to
-// `exclude`); a no-op for anything already in `dependencies`.
-export const additionalDependencies = {
-	cli: false,
-	type: ["string", "list"],
-	default: [],
-	normalize: (v, defaultValue) => (v == null ? defaultValue : [v].flat()),
-};
-
-// Packages to keep in the import map even when `prune` is true. Like `additionalDependencies`,
-// but not subject to pruning — use for packages you always want available regardless of whether
-// the entry points reference them. Subject to `exclude` (a name in both is excluded, with a warning).
-export const forceDependencies = {
-	cli: false,
-	type: ["string", "list"],
-	default: [],
-	normalize: (v, defaultValue) => (v == null ? defaultValue : [v].flat()),
-};
-
 export const prune = {
 	type: "boolean",
 	default: false,
@@ -121,7 +118,15 @@ export const init = {
 	default: false,
 };
 
+// Conditional overrides: per package, per mode, or unconditional.
+// Normalization and validation live in rules.js, orchestrated by getConfig.
 export const overrides = {
+	cli: false,
+	type: ["object", "list"],
+};
+
+// Import map entries merged into the generated map (specifier → path/URL).
+export const imports = {
 	cli: false,
 	type: "object",
 };
@@ -133,8 +138,7 @@ export const hooks = {
 
 // The directory the host serves as `/`. Only needed when `dir` lives inside a build output
 // directory (e.g. an SSG's `dist/`), since redirect rules are URLs, not file paths.
-export const publishDir = {
-	flag: "publish-dir",
+export const root = {
 	type: "string",
 };
 
@@ -148,11 +152,10 @@ export const cjs = {
 	default: true,
 };
 
-export const combineSubpaths = {
-	flag: "combine-subpaths",
-	type: ["boolean", "string"],
-	default: false,
-	validate: v => typeof v === "boolean" || v === "both",
+export const subpaths = {
+	type: "string",
+	default: "split",
+	validate: v => ["split", "combined", "both"].includes(v),
 };
 
 export const ignore = {
@@ -177,17 +180,7 @@ export const ignore = {
 			value = defaultValue;
 		}
 
-		value = value.map(p => {
-			p = typeof p === "string" ? { exclude: p } : p;
-
-			if (p.packageName && !Array.isArray(p.packageName)) {
-				p.packageName = [p.packageName];
-			}
-
-			return p;
-		});
-
-		return value;
+		return value.map(p => (typeof p === "string" ? { ignore: p } : p));
 	},
 };
 
@@ -197,12 +190,12 @@ export const symlink = {
 };
 
 export const preserveSymlinks = {
-	type: ["boolean", "list", "function"],
+	type: "boolean",
 	default: false,
 };
 
 export const alias = {
-	type: ["boolean", "string", "list", "object", "function"],
+	type: ["boolean", "string"],
 	default: true,
 };
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -1,0 +1,241 @@
+/**
+ * Conditional config overrides: the rule matching engine and the built-in rules.
+ * A rule is an object mixing matcher fields (which packages/modes it applies to)
+ * with option values to override. See the `overrides` option.
+ */
+import { SemverRange } from "sver";
+import * as availableOptions from "./options.js";
+import { suggest } from "./util/options.js";
+
+/**
+ * Fields that select what a rule applies to. `package` is the internal form of the
+ * dictionary shorthand: an exact string matched against name OR installName.
+ */
+export const MATCHERS = ["name", "installName", "version", "mode", "package"];
+
+// Rule-only settings that are not top-level options
+const RULE_ONLY = new Set(["include"]);
+
+// Options that only make sense per package
+const PACKAGE_SCOPED = new Set([
+	"dir",
+	"symlink",
+	"preserveSymlinks",
+	"alias",
+	"ignore",
+	"imports",
+	"cjs",
+]);
+
+// Options no rule may set: they decide what runs, before rules exist
+const TOP_ONLY = new Set(["mode", "config", "init", "overrides"]);
+
+/**
+ * Built-in mode presets, as rules. They sit below top-level config in the cascade,
+ * so an explicit config value beats them; user rules sit above.
+ */
+export const builtInRules = [
+	{ mode: "dev", symlink: true },
+	{ mode: "prod", symlink: false, prune: true, terse: true },
+];
+
+export const builtInModes = new Set(builtInRules.flatMap(rule => [rule.mode].flat()));
+
+/**
+ * Does this rule constrain which packages it applies to?
+ * Mode-only and unconditional rules apply globally.
+ */
+export function isPackageRule (rule) {
+	return ["name", "installName", "version", "package"].some(key => rule[key] !== undefined);
+}
+
+/**
+ * Match one matcher value (string | RegExp | function | array of these) against a subject value.
+ * Strings are exact, except `version`, where they are semver ranges.
+ */
+function matchesValue (matcher, value, key) {
+	if (Array.isArray(matcher)) {
+		return matcher.some(m => matchesValue(m, value, key));
+	}
+
+	if (matcher instanceof RegExp) {
+		return value !== undefined && matcher.test(value);
+	}
+
+	if (typeof matcher === "function") {
+		return Boolean(matcher(value));
+	}
+
+	if (key === "version") {
+		return value !== undefined && SemverRange.match(matcher, value);
+	}
+
+	return matcher === value;
+}
+
+/**
+ * Does a rule apply to a subject ({name, installName, version, mode})?
+ * All matcher fields present must match (AND); a rule with none matches everything.
+ */
+export function matches (rule, subject) {
+	for (let key of MATCHERS) {
+		let matcher = rule[key];
+		if (matcher === undefined) {
+			continue;
+		}
+
+		if (key === "package") {
+			if (matcher !== subject.name && matcher !== subject.installName) {
+				return false;
+			}
+		}
+		else if (!matchesValue(matcher, subject[key], key)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Apply the matching subset of rules to a base config, per property, later rules winning.
+ * `ignore` is additive: rule entries append to the base list instead of replacing it,
+ * matching how the built-in ignore defaults always apply.
+ * @returns {object} A new object; `base` is not mutated. Matcher fields are not copied.
+ */
+export function applyRules (base, rules, subject) {
+	let ret = { ...base };
+
+	for (let rule of rules) {
+		if (!matches(rule, subject)) {
+			continue;
+		}
+
+		for (let key in rule) {
+			if (MATCHERS.includes(key)) {
+				continue;
+			}
+
+			if (key === "ignore") {
+				ret.ignore = [...(ret.ignore ?? []), ...rule.ignore];
+			}
+			else {
+				ret[key] = rule[key];
+			}
+		}
+	}
+
+	return ret;
+}
+
+/**
+ * Normalize the `overrides` option into the canonical array-of-rules form:
+ * dictionary entries become rules with the internal `package` matcher,
+ * and nested `ignore` values get the same shape as the top-level option
+ * (minus the built-in defaults, which the global list already carries).
+ */
+export function normalizeRules (value) {
+	if (!value) {
+		return [];
+	}
+
+	let rules = Array.isArray(value)
+		? value
+		: Object.entries(value).map(([key, rule]) => ({ package: key, ...rule }));
+
+	return rules.map(rule => {
+		if (rule.ignore !== undefined) {
+			rule = {
+				...rule,
+				ignore: [rule.ignore].flat().map(p => (typeof p === "string" ? { ignore: p } : p)),
+			};
+		}
+
+		return rule;
+	});
+}
+
+/**
+ * Extract the exact package names a matcher can produce, or null if it is a pattern
+ * (regex/function) that cannot be enumerated.
+ */
+function exactNames (matcher) {
+	let values = [matcher].flat();
+	return values.every(v => typeof v === "string") ? values : null;
+}
+
+/**
+ * Validate normalized rules; throws on structural errors.
+ * @param {object[]} rules
+ * @param {Set<string>} [optionKeys] - Known top-level option names
+ */
+export function validateRules (rules, optionKeys = new Set(Object.keys(availableOptions))) {
+	for (let rule of rules) {
+		if (typeof rule !== "object" || rule === null) {
+			throw new Error(`Invalid overrides rule: ${JSON.stringify(rule)}. Expected an object.`);
+		}
+
+		let packageRule = isPackageRule(rule);
+
+		for (let key in rule) {
+			if (MATCHERS.includes(key)) {
+				continue;
+			}
+
+			if (!optionKeys.has(key) && !RULE_ONLY.has(key)) {
+				let suggestion = suggest(key, [...optionKeys, ...RULE_ONLY, ...MATCHERS]);
+				let hint = suggestion ? ` Did you mean "${suggestion}"?` : "";
+				throw new Error(`Unknown key "${key}" in overrides rule.${hint}`);
+			}
+
+			if (TOP_ONLY.has(key)) {
+				throw new Error(`Option "${key}" cannot be set from an overrides rule.`);
+			}
+
+			if (packageRule && !PACKAGE_SCOPED.has(key) && !RULE_ONLY.has(key)) {
+				throw new Error(
+					`Option "${key}" is not package-scoped, so a package-matched overrides rule cannot set it.`,
+				);
+			}
+		}
+
+		let { include } = rule;
+		if (include !== undefined) {
+			if (![true, false, "force"].includes(include)) {
+				throw new Error(
+					`Invalid include value in overrides rule: ${JSON.stringify(include)}. Expected true, false, or "force".`,
+				);
+			}
+
+			if (!packageRule) {
+				throw new Error(`include requires a rule that names packages.`);
+			}
+
+			// Installing needs concrete names — patterns can only drop
+			if (include !== false && includeNames(rule) === null) {
+				throw new Error(
+					`include: ${JSON.stringify(include)} requires exact package names to install, not patterns.`,
+				);
+			}
+		}
+	}
+}
+
+/**
+ * The exact package names a rule's package matchers name, or null when they are patterns.
+ * @returns {string[] | null}
+ */
+export function includeNames (rule) {
+	let matchers = [rule.package, rule.name, rule.installName].filter(m => m !== undefined);
+	let names = [];
+
+	for (let matcher of matchers) {
+		let exact = exactNames(matcher);
+		if (exact === null) {
+			return null;
+		}
+		names.push(...exact);
+	}
+
+	return names;
+}

--- a/src/util/options.js
+++ b/src/util/options.js
@@ -1,0 +1,104 @@
+/**
+ * Helpers for the option registry: type checking and CLI coercion,
+ * typo suggestions, and config serialization for cache comparison.
+ */
+
+/**
+ * Check a value against an option's declared type(s).
+ * @param {any} value
+ * @param {string | string[]} [type] - "boolean" | "string" | "number" | "list" | "object" | "function", or an array of these
+ * @returns {boolean}
+ */
+export function checkType (value, type) {
+	if (!type) {
+		return true;
+	}
+
+	return [type].flat().some(t => {
+		if (t === "list") {
+			return Array.isArray(value);
+		}
+
+		if (t === "object") {
+			return typeof value === "object" && value !== null && !Array.isArray(value);
+		}
+
+		return typeof value === t;
+	});
+}
+
+/**
+ * Coerce a CLI string into an option's type where unambiguous:
+ * "true"/"false" for boolean-accepting options. Anything else passes
+ * through for the option's own `parse` or validation to handle.
+ * @param {any} value
+ * @param {string | string[]} [type]
+ */
+export function coerce (value, type) {
+	if (typeof value !== "string" || !type) {
+		return value;
+	}
+
+	if ([type].flat().includes("boolean") && (value === "true" || value === "false")) {
+		return value === "true";
+	}
+
+	return value;
+}
+
+/**
+ * Suggest the closest known name for a typo, or undefined if nothing is close.
+ * @param {string} name
+ * @param {string[]} candidates
+ */
+export function suggest (name, candidates) {
+	let best;
+	let bestDistance = Math.max(2, Math.floor(name.length / 3));
+
+	for (let candidate of candidates) {
+		let distance = levenshtein(name.toLowerCase(), candidate.toLowerCase());
+		if (distance <= bestDistance) {
+			best = candidate;
+			bestDistance = distance;
+		}
+	}
+
+	return best;
+}
+
+function levenshtein (a, b) {
+	let row = Array.from({ length: b.length + 1 }, (_, i) => i);
+
+	for (let i = 1; i <= a.length; i++) {
+		let prev = row[0]++;
+
+		for (let j = 1; j <= b.length; j++) {
+			let current = row[j];
+			row[j] = Math.min(current + 1, row[j - 1] + 1, prev + (a[i - 1] !== b[j - 1]));
+			prev = current;
+		}
+	}
+
+	return row[b.length];
+}
+
+/**
+ * Serialize a config object so that function and regex values survive as their source text.
+ * Idempotent across a write/read/write cycle, so it can be used both to persist
+ * `.nudeps/config.json` and to compare against it for cache invalidation.
+ * @param {object} config
+ * @returns {string}
+ */
+export function stringifyConfig (config) {
+	return JSON.stringify(
+		config,
+		(key, value) => {
+			if (typeof value === "function" || value instanceof RegExp) {
+				return String(value);
+			}
+
+			return value;
+		},
+		"\t",
+	);
+}

--- a/test/config/hardening.js
+++ b/test/config/hardening.js
@@ -1,0 +1,148 @@
+import { getConfig } from "../../src/config.js";
+import readArgs from "../../src/cli/args.js";
+import { stringifyConfig, suggest } from "../../src/util/options.js";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// getConfig() reads the config file off disk, so these are written out rather than passed in
+let dir = mkdtempSync(join(tmpdir(), "nudeps-hardening-"));
+function configFile (name, source) {
+	let file = join(dir, name);
+	writeFileSync(file, source);
+	return file;
+}
+
+const TYPO = configFile("typo.js", `export default { trese: true };`);
+const BAD_TYPE = configFile("bad-type.js", `export default { publishDir: 42 };`);
+const BAD_ENUM = configFile("bad-enum.js", `export default { combineSubpaths: "nope" };`);
+const STRING_EXCLUDE = configFile("string-exclude.js", `export default { exclude: "foo" };`);
+const HOST = configFile("host.js", `export default { host: "netlify" };`);
+const BAD_HOST = configFile("bad-host.js", `export default { host: "geocities" };`);
+
+export default {
+	name: "Config pipeline hardening",
+	afterAll () {
+		rmSync(dir, { recursive: true, force: true });
+	},
+	tests: [
+		{
+			name: "Loud failures",
+			run: getConfig,
+			tests: [
+				{
+					name: "unknown config key throws with a suggestion",
+					arg: { config: TYPO },
+					throws: e => e.message.includes("trese") && e.message.includes("terse"),
+				},
+				{
+					name: "invalid type throws and names the source",
+					arg: { config: BAD_TYPE },
+					throws: e =>
+						e.message.includes("publishDir") && e.message.includes("config file"),
+				},
+				{
+					name: "failing validate throws",
+					arg: { config: BAD_ENUM },
+					throws: e => e.message.includes("combineSubpaths"),
+				},
+				{
+					name: "invalid programmatic value throws and names the source",
+					arg: { config: HOST, terse: "yes" },
+					throws: e => e.message.includes("terse") && e.message.includes("options"),
+				},
+				{
+					name: "explicitly passed missing config file throws",
+					arg: { config: join(dir, "does-not-exist.js") },
+					throws: e => e.message.includes("does not exist"),
+				},
+				{
+					name: "unknown host throws",
+					arg: { config: BAD_HOST },
+					throws: e => e.message.includes("host"),
+				},
+			],
+		},
+		{
+			name: "Normalization and registration",
+			run: getConfig,
+			check: { subset: true, deep: true },
+			tests: [
+				{
+					name: "a string exclude becomes a one-element array",
+					arg: { config: STRING_EXCLUDE },
+					expect: { exclude: ["foo"] },
+				},
+				{
+					name: "host is a real option",
+					arg: { config: HOST },
+					expect: { host: "netlify" },
+				},
+			],
+		},
+		{
+			name: "CLI coercion",
+			run: readArgs,
+			check: { deep: true },
+			tests: [
+				{
+					name: "--symlink=false coerces to a boolean",
+					arg: ["--symlink=false"],
+					expect: { symlink: false },
+				},
+				{
+					name: "-e a,b splits into a list",
+					arg: ["-e", "a,b"],
+					expect: { exclude: ["a", "b"] },
+				},
+				{
+					name: "--alias=header stays a string",
+					arg: ["--alias=header"],
+					expect: { alias: "header" },
+				},
+				{
+					name: "an invalid value is passed through for getConfig to reject",
+					arg: ["--terse=yes"],
+					expect: { terse: "yes" },
+				},
+			],
+		},
+		{
+			name: "Config serialization for cache comparison",
+			tests: [
+				{
+					name: "different functions produce different serializations",
+					run: () =>
+						stringifyConfig({ symlink: pkg => pkg.isExternal }) ===
+						stringifyConfig({ symlink: () => true }),
+					expect: false,
+				},
+				{
+					name: "survives a write/parse/write round trip unchanged",
+					run () {
+						let config = { symlink: pkg => pkg.isExternal, exclude: ["foo"] };
+						let once = stringifyConfig(config);
+						return stringifyConfig(JSON.parse(once)) === once;
+					},
+					expect: true,
+				},
+			],
+		},
+		{
+			name: "suggest()",
+			run: suggest,
+			tests: [
+				{
+					name: "close typo",
+					args: ["trese", ["terse", "prune", "dir"]],
+					expect: "terse",
+				},
+				{
+					name: "nothing close",
+					args: ["zebra", ["terse", "prune", "dir"]],
+					expect: undefined,
+				},
+			],
+		},
+	],
+};

--- a/test/config/hardening.js
+++ b/test/config/hardening.js
@@ -14,11 +14,19 @@ function configFile (name, source) {
 }
 
 const TYPO = configFile("typo.js", `export default { trese: true };`);
-const BAD_TYPE = configFile("bad-type.js", `export default { publishDir: 42 };`);
-const BAD_ENUM = configFile("bad-enum.js", `export default { combineSubpaths: "nope" };`);
-const STRING_EXCLUDE = configFile("string-exclude.js", `export default { exclude: "foo" };`);
+const BAD_TYPE = configFile("bad-type.js", `export default { root: 42 };`);
+const BAD_ENUM = configFile("bad-enum.js", `export default { subpaths: "nope" };`);
+const RENAMED = configFile("renamed.js", `export default { exclude: ["foo"] };`);
+const OLD_OVERRIDES = configFile(
+	"old-overrides.js",
+	`export default { overrides: { imports: { foo: "./node_modules/foo/foo.js" } } };`,
+);
 const HOST = configFile("host.js", `export default { host: "netlify" };`);
 const BAD_HOST = configFile("bad-host.js", `export default { host: "geocities" };`);
+const RULES = configFile(
+	"rules.js",
+	`export default { overrides: [{ mode: "loud", terse: true }] };`,
+);
 
 export default {
 	name: "Config pipeline hardening",
@@ -38,13 +46,23 @@ export default {
 				{
 					name: "invalid type throws and names the source",
 					arg: { config: BAD_TYPE },
-					throws: e =>
-						e.message.includes("publishDir") && e.message.includes("config file"),
+					throws: e => e.message.includes("root") && e.message.includes("config file"),
 				},
 				{
 					name: "failing validate throws",
 					arg: { config: BAD_ENUM },
-					throws: e => e.message.includes("combineSubpaths"),
+					throws: e => e.message.includes("subpaths"),
+				},
+				{
+					name: "renamed keys point at the replacement",
+					arg: { config: RENAMED },
+					throws: e =>
+						e.message.includes("exclude") && e.message.includes("include: false"),
+				},
+				{
+					name: "old import-map-shaped overrides point at imports",
+					arg: { config: OLD_OVERRIDES },
+					throws: e => e.message.includes(`"imports"`),
 				},
 				{
 					name: "invalid programmatic value throws and names the source",
@@ -69,14 +87,29 @@ export default {
 			check: { subset: true, deep: true },
 			tests: [
 				{
-					name: "a string exclude becomes a one-element array",
-					arg: { config: STRING_EXCLUDE },
-					expect: { exclude: ["foo"] },
-				},
-				{
 					name: "host is a real option",
 					arg: { config: HOST },
 					expect: { host: "netlify" },
+				},
+				{
+					name: "overrides concatenate across layers instead of replacing",
+					arg: {
+						config: RULES,
+						mode: "loud",
+						overrides: [{ mode: "loud", prune: true }],
+					},
+					expect: { terse: true, prune: true },
+				},
+			],
+		},
+		{
+			name: "Programmatic misuse",
+			run: getConfig,
+			tests: [
+				{
+					name: "renamed options error for programmatic callers too",
+					arg: { config: HOST, additionalDependencies: ["x"] },
+					throws: e => e.message.includes("include: true"),
 				},
 			],
 		},
@@ -89,11 +122,6 @@ export default {
 					name: "--symlink=false coerces to a boolean",
 					arg: ["--symlink=false"],
 					expect: { symlink: false },
-				},
-				{
-					name: "-e a,b splits into a list",
-					arg: ["-e", "a,b"],
-					expect: { exclude: ["a", "b"] },
 				},
 				{
 					name: "--alias=header stays a string",
@@ -120,7 +148,7 @@ export default {
 				{
 					name: "survives a write/parse/write round trip unchanged",
 					run () {
-						let config = { symlink: pkg => pkg.isExternal, exclude: ["foo"] };
+						let config = { symlink: pkg => pkg.isExternal, ignore: ["foo"] };
 						let once = stringifyConfig(config);
 						return stringifyConfig(JSON.parse(once)) === once;
 					},

--- a/test/config/index.js
+++ b/test/config/index.js
@@ -1,8 +1,9 @@
 import modeResolution from "./mode-resolution.js";
 import optionResolution from "./option-resolution.js";
 import hardening from "./hardening.js";
+import rules from "./rules.js";
 
 export default {
 	name: "config tests",
-	tests: [modeResolution, optionResolution, hardening],
+	tests: [modeResolution, optionResolution, hardening, rules],
 };

--- a/test/config/index.js
+++ b/test/config/index.js
@@ -1,7 +1,8 @@
 import modeResolution from "./mode-resolution.js";
 import optionResolution from "./option-resolution.js";
+import hardening from "./hardening.js";
 
 export default {
 	name: "config tests",
-	tests: [modeResolution, optionResolution],
+	tests: [modeResolution, optionResolution, hardening],
 };

--- a/test/config/mode-resolution.js
+++ b/test/config/mode-resolution.js
@@ -1,105 +1,104 @@
-import { resolveDefaults } from "../../src/config.js";
-import builtInModes from "../../src/modes.js";
+import { getConfig } from "../../src/config.js";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// getConfig() reads the config file off disk, so these are written out rather than passed in
+let dir = mkdtempSync(join(tmpdir(), "nudeps-modes-"));
+function configFile (name, source) {
+	let file = join(dir, name);
+	writeFileSync(file, source);
+	return file;
+}
+
+const EMPTY = configFile("empty.js", `export default {};`);
+const STAGING = configFile(
+	"staging.js",
+	`export default {
+		overrides: [
+			{ mode: ["prod", "staging"], prune: true },
+			{ mode: "staging", terse: false },
+		],
+	};`,
+);
+const EXPLICIT = configFile(
+	"explicit.js",
+	`export default { terse: false, overrides: [{ mode: "loud", terse: true }] };`,
+);
+const UNCONDITIONAL = configFile(
+	"unconditional.js",
+	`export default { terse: false, overrides: [{ terse: true }] };`,
+);
 
 export default {
-	name: "resolveDefaults",
-	data: { modes: builtInModes },
-	run (name) {
-		return resolveDefaults(name, this.data.modes);
+	name: "Modes as rules: cascade and origin order",
+	run: getConfig,
+	// Only the options each test is about; the rest of the resolved config is irrelevant here
+	check: { subset: true, deep: true },
+	afterAll () {
+		rmSync(dir, { recursive: true, force: true });
 	},
 	tests: [
 		{
-			name: "built-in modes",
-			tests: [
-				{
-					arg: "dev",
-					expect: { symlink: true },
-				},
-				{
-					arg: "prod",
-					expect: { symlink: false, prune: true, terse: true },
-				},
-			],
+			name: "built-in dev preset",
+			arg: { config: EMPTY, mode: "dev" },
+			expect: { symlink: true },
 		},
 		{
-			name: "custom mode inheriting from prod",
-			data: {
-				modes: {
-					...builtInModes,
-					staging: { mode: "prod", prune: false },
-				},
+			name: "built-in prod preset",
+			arg: { config: EMPTY, mode: "prod" },
+			expect: { symlink: false, prune: true, terse: true },
+		},
+		{
+			name: "no mode: presets stay dormant",
+			arg: { config: EMPTY },
+			expect: { prune: false, terse: false },
+		},
+		{
+			name: "mode group (any-of matcher) replaces mode-extends",
+			arg: { config: STAGING, mode: "staging" },
+			expect: { prune: true, terse: false },
+		},
+		{
+			name: "group rule alone applies to the other listed mode",
+			arg: { config: STAGING, mode: "prod" },
+			expect: { prune: true, terse: true },
+		},
+		{
+			name: "explicit top-level value beats a built-in preset",
+			async run (options) {
+				let config = await getConfig(options);
+				return config.terse;
 			},
-			tests: [
-				{
-					arg: "staging",
-					expect: { symlink: false, prune: false, terse: true },
-				},
-			],
+			arg: { config: EXPLICIT, mode: "prod" },
+			expect: false,
 		},
 		{
-			name: "custom mode extending same-named built-in",
-			data: {
-				modes: {
-					...builtInModes,
-					prod: { mode: "prod", prune: false },
-				},
+			name: "a user mode rule beats a top-level value",
+			arg: { config: EXPLICIT, mode: "loud" },
+			expect: { terse: true },
+		},
+		{
+			name: "an unconditional rule beats a top-level value",
+			arg: { config: UNCONDITIONAL },
+			expect: { terse: true },
+		},
+		{
+			name: "unknown active mode warns but still resolves",
+			async run (options) {
+				let warned = "";
+				let original = console.warn;
+				console.warn = msg => (warned += msg);
+				try {
+					await getConfig(options);
+				}
+				finally {
+					console.warn = original;
+				}
+				return warned.includes(`Unknown mode "nonexistent"`);
 			},
-			tests: [
-				{
-					arg: "prod",
-					expect: { symlink: false, prune: false, terse: true },
-				},
-			],
-		},
-		{
-			name: "deep inheritance chain",
-			data: {
-				modes: {
-					base: { a: 1 },
-					mid: { mode: "base", b: 2 },
-					leaf: { mode: "mid", c: 3 },
-				},
-			},
-			tests: [
-				{
-					arg: "leaf",
-					expect: { a: 1, b: 2, c: 3 },
-				},
-			],
-		},
-		{
-			name: "cycle detection",
-			data: {
-				modes: {
-					a: { mode: "b" },
-					b: { mode: "a" },
-				},
-			},
-			tests: [
-				{
-					arg: "a",
-					expect: {},
-				},
-			],
-		},
-		{
-			name: "unknown mode",
-			data: { modes: { dev: { symlink: true } } },
-			tests: [
-				{
-					arg: "nonexistent",
-					expect: {},
-				},
-			],
-		},
-		{
-			name: "undefined mode",
-			tests: [
-				{
-					arg: undefined,
-					expect: {},
-				},
-			],
+			arg: { config: STAGING, mode: "nonexistent" },
+			expect: true,
 		},
 	],
 };

--- a/test/config/option-resolution.js
+++ b/test/config/option-resolution.js
@@ -26,8 +26,8 @@ export default {
 	tests: [
 		{
 			name: "defaults fill in options no other layer sets, beating built-in option defaults",
-			arg: { config: CONFIG, defaults: { map: "dist/importmap.js", publishDir: "dist" } },
-			expect: { map: "dist/importmap.js", publishDir: "dist" },
+			arg: { config: CONFIG, defaults: { map: "dist/importmap.js", root: "dist" } },
+			expect: { map: "dist/importmap.js", root: "dist" },
 		},
 		{
 			name: "config file beats defaults",

--- a/test/config/rules.js
+++ b/test/config/rules.js
@@ -1,0 +1,173 @@
+import {
+	matches,
+	applyRules,
+	normalizeRules,
+	validateRules,
+	isPackageRule,
+	includeNames,
+} from "../../src/rules.js";
+
+const PKG = { name: "leaflet", installName: "leaflet", version: "1.9.4", mode: "prod" };
+
+export default {
+	name: "Override rule engine",
+	tests: [
+		{
+			name: "matches()",
+			run: matches,
+			tests: [
+				{ name: "exact name", args: [{ name: "leaflet" }, PKG], expect: true },
+				{ name: "wrong name", args: [{ name: "vue" }, PKG], expect: false },
+				{
+					name: "regex installName",
+					args: [{ installName: /^leaf/ }, PKG],
+					expect: true,
+				},
+				{
+					name: "predicate on the field value",
+					args: [{ name: n => n.length > 3 }, PKG],
+					expect: true,
+				},
+				{
+					name: "any-of array",
+					args: [{ name: ["vue", "leaflet"] }, PKG],
+					expect: true,
+				},
+				{
+					name: "semver range version",
+					args: [{ name: "leaflet", version: "^1" }, PKG],
+					expect: true,
+				},
+				{
+					name: "semver range excludes other majors",
+					args: [{ name: "leaflet", version: "^2" }, PKG],
+					expect: false,
+				},
+				{
+					name: "multiple fields AND",
+					args: [{ name: "leaflet", mode: "dev" }, PKG],
+					expect: false,
+				},
+				{ name: "no matchers = unconditional", args: [{ terse: true }, PKG], expect: true },
+				{
+					name: "dictionary key matches installName too",
+					args: [{ package: "jquery1" }, { name: "jquery", installName: "jquery1" }],
+					expect: true,
+				},
+			],
+		},
+		{
+			name: "applyRules()",
+			check: { deep: true },
+			tests: [
+				{
+					name: "later rule wins per property, non-matching skipped",
+					run: () =>
+						applyRules(
+							{ symlink: false, terse: false },
+							[
+								{ name: "leaflet", symlink: true },
+								{ name: "vue", terse: true },
+								{ name: "leaflet", version: "^1", symlink: false },
+							],
+							PKG,
+						),
+					expect: { symlink: false, terse: false },
+				},
+				{
+					name: "ignore appends instead of replacing",
+					run: () =>
+						applyRules(
+							{ ignore: [{ ignore: "*.map" }] },
+							[{ name: "leaflet", ignore: [{ ignore: "docs/**" }] }],
+							PKG,
+						).ignore,
+					expect: [{ ignore: "*.map" }, { ignore: "docs/**" }],
+				},
+			],
+		},
+		{
+			name: "normalizeRules()",
+			check: { deep: true },
+			tests: [
+				{
+					name: "dictionary desugars to package rules",
+					run: () => normalizeRules({ "open-props": { alias: "../open-props" } }),
+					expect: [{ package: "open-props", alias: "../open-props" }],
+				},
+				{
+					name: "nested ignore strings get the canonical shape",
+					run: () => normalizeRules([{ name: "leaflet", ignore: "docs/**" }]),
+					expect: [{ name: "leaflet", ignore: [{ ignore: "docs/**" }] }],
+				},
+			],
+		},
+		{
+			name: "validateRules()",
+			run: rules => validateRules(normalizeRules(rules)),
+			tests: [
+				{
+					name: "package rule cannot set a global option",
+					arg: [{ name: "leaflet", terse: true }],
+					throws: e => e.message.includes("not package-scoped"),
+				},
+				{
+					name: "mode in a rule is a matcher, not a setting (package × mode is legal)",
+					arg: [{ name: "leaflet", mode: "prod", symlink: false }],
+					expect: undefined,
+				},
+				{
+					name: "rules cannot set top-only options",
+					arg: [{ init: true }],
+					throws: e => e.message.includes(`"init"`),
+				},
+				{
+					name: "unknown rule key throws with suggestion",
+					arg: [{ name: "leaflet", alais: true }],
+					throws: e => e.message.includes("alais") && e.message.includes("alias"),
+				},
+				{
+					name: "include with a pattern matcher cannot install",
+					arg: [{ name: /^@types\//, include: true }],
+					throws: e => e.message.includes("exact package names"),
+				},
+				{
+					name: "include: false accepts patterns",
+					arg: [{ name: /^@types\//, include: false }],
+					expect: undefined,
+				},
+				{
+					name: "include requires naming packages",
+					arg: [{ mode: "prod", include: false }],
+					throws: e => e.message.includes("names packages"),
+				},
+			],
+		},
+		{
+			name: "helpers",
+			tests: [
+				{
+					name: "isPackageRule: mode-only is global",
+					run: () => isPackageRule({ mode: "prod", terse: true }),
+					expect: false,
+				},
+				{
+					name: "isPackageRule: version counts",
+					run: () => isPackageRule({ version: "^1", symlink: false }),
+					expect: true,
+				},
+				{
+					name: "includeNames returns exact names",
+					run: () => includeNames({ name: ["chai", "sinon"], include: true }),
+					check: { deep: true },
+					expect: ["chai", "sinon"],
+				},
+				{
+					name: "includeNames is null for patterns",
+					run: () => includeNames({ name: /^@types\//, include: false }),
+					expect: null,
+				},
+			],
+		},
+	],
+};

--- a/test/e2e/additional-dependencies.js
+++ b/test/e2e/additional-dependencies.js
@@ -8,10 +8,10 @@ const NUDEPS_ROOT = resolve(import.meta.dirname, "../..");
 // Reproduces a tool (e.g. a static site generator) injecting its own client library into a
 // consumer's import map. `mitt` is present only as a devDependency, so npm flags it dev:true
 // in the lockfile and the root trace never reaches it — it lands in the map purely because of
-// additionalDependencies. Exercises dev-flag retention too: a dev-flagged package must resolve
+// an include: true rule. Exercises dev-flag retention too: a dev-flagged package must resolve
 // and copy, not just appear as a map entry.
 export default {
-	name: "additionalDependencies injects a package the host doesn't depend on",
+	name: "include: true injects a package the host doesn't depend on",
 	async run () {
 		let tmpDir = mkdtempSync(join(tmpdir(), "nudeps-additional-deps-"));
 		try {
@@ -29,7 +29,7 @@ export default {
 			// A consumer calling nudeps programmatically and injecting its own client library.
 			writeFileSync(
 				join(tmpDir, "build.mjs"),
-				`import nudeps from "nudeps";\nawait nudeps({ additionalDependencies: ["mitt"] });\n`,
+				`import nudeps from "nudeps";\nawait nudeps({ overrides: [{ name: "mitt", include: true }] });\n`,
 			);
 
 			let env = { ...process.env, npm_config_audit: "false", npm_config_fund: "false" };

--- a/test/e2e/force-dependencies.js
+++ b/test/e2e/force-dependencies.js
@@ -5,14 +5,14 @@ import { join, resolve } from "node:path";
 
 const NUDEPS_ROOT = resolve(import.meta.dirname, "../..");
 
-// The full forceDependencies contract, under `prune: true`, on one package (`mitt`):
-//   - additionalDependencies → pruned away (control: proves prune really drops it)
-//   - forceDependencies       → kept (the feature)
-//   - forceDependencies + exclude → still dropped, with a warning (exclude wins over force)
+// The full include contract, under `prune: true`, on one package (`mitt`):
+//   - include: true    → pruned away (control: proves prune really drops it)
+//   - include: "force" → kept (the feature)
+//   - a later include: false rule → dropped again (the cascade resolves the contradiction)
 // mitt is a devDependency and the entry point imports nothing, so it only reaches the map via
 // injection — exactly the intended use case (a dev-only client lib you always want present).
 export default {
-	name: "forceDependencies survives prune but still respects exclude",
+	name: 'include: "force" survives prune; a later include: false wins the cascade',
 	async run () {
 		let tmpDir = mkdtempSync(join(tmpdir(), "nudeps-force-deps-"));
 		try {
@@ -37,9 +37,9 @@ export default {
 				`import nudeps from "nudeps";\n` +
 					`let opts = { prune: true, init: true };\n` +
 					`let mode = process.env.MODE;\n` +
-					`if (mode === "force") { opts.forceDependencies = ["mitt"]; }\n` +
-					`else if (mode === "contradiction") { opts.forceDependencies = ["mitt"]; opts.exclude = ["mitt"]; }\n` +
-					`else { opts.additionalDependencies = ["mitt"]; }\n` +
+					`if (mode === "force") { opts.overrides = [{ name: "mitt", include: "force" }]; }\n` +
+					`else if (mode === "contradiction") { opts.overrides = [{ name: "mitt", include: "force" }, { name: "mitt", include: false }]; }\n` +
+					`else { opts.overrides = [{ name: "mitt", include: true }]; }\n` +
 					`await nudeps(opts);\n`,
 			);
 
@@ -57,28 +57,26 @@ export default {
 
 			execSync("npm install", { cwd: tmpDir, env, stdio: "ignore" });
 
-			run("additional"); // control: additionalDependencies is pruned away
+			run("additional"); // control: include: true is pruned away
 			let pruned = mittUrl();
 
-			run("force"); // forceDependencies survives the prune
+			run("force"); // include: "force" survives the prune
 			let forced = mittUrl();
 
-			let output = run("contradiction"); // exclude wins over force, with a warning
+			run("contradiction"); // the later include: false rule wins
 			let excluded = mittUrl();
-			let warned = /exclude wins/i.test(output);
 
-			return { pruned, forced, excluded, warned };
+			return { pruned, forced, excluded };
 		}
 		finally {
 			rmSync(tmpDir, { recursive: true, force: true });
 		}
 	},
-	// Control dropped mitt; force brought it back (copied, versioned); exclude dropped it again and warned.
-	check: ({ pruned, forced, excluded, warned }) =>
+	// Control dropped mitt; force brought it back (copied, versioned); the later rule dropped it again.
+	check: ({ pruned, forced, excluded }) =>
 		pruned === null &&
 		typeof forced === "string" &&
 		forced.includes("mitt@") &&
-		excluded === null &&
-		warned === true,
+		excluded === null,
 	expect: true,
 };


### PR DESCRIPTION
Implements the config schema redesign from #154 (see the issue for the full review that motivated it, and for the release checklist — kept open until release).

## What changed

**Pipeline hardening** (non-breaking):
- Option descriptors declare an explicit `type`; CLI coercion is type-driven (fixes `--symlink=false` arriving as the string `"false"`)
- Invalid values throw with the offending key, value, and source (CLI / config file / rule) instead of silently falling back to defaults; `--config=missing.js` is no longer a silent no-op
- Unknown config keys error with a nearest-name suggestion; renamed keys point at their replacement — for programmatic callers too
- `host` is a real, validated option (it was read but never registered)
- `.nudeps/config.json` is written and compared via a serializer that keeps function values as source text, so editing a `symlink` callback or `hooks` busts the install cache

**Conditional `overrides`** (breaking):
- One mechanism for per-package settings, mode presets, and combinations: rules matching `name` / `installName` / `version` (semver range) / `mode` — exact strings, regexes, predicates, or any-of arrays — with a dictionary shorthand for single exact names
- Cascade: all matching rules apply in order, later wins, merged per property; origin order defaults < built-in mode rules < top-level config < user rules < args. Rule layers concatenate, so programmatic rules compose with the config file's
- `include: "force" | true | false | undefined` replaces `exclude`/`additionalDependencies`/`forceDependencies` (the force∩exclude warning disappears structurally)
- `modes` and its recursive extends-resolution deleted — a mode preset is a rule with a `mode` matcher; grouping via any-of matchers
- Map-merge `overrides` → `imports`: the platform's import-map `imports` shape, and inside package rules values are package-relative (no more `./node_modules/` paths)
- `combineSubpaths` → `subpaths` enum; `publishDir` → `root`; `ignore` uses explicit `ignore`/`copy` polarity keys; per-package `dir` and `cjs` are new capabilities

## Verification

- 204 unit + 7 e2e tests pass
- All 13 demo maps regenerate byte-identical against a pre-change baseline (`npm run init-demos` + diff)
- Both real-world configs in the wild migrate byte-identically: `color-js/apps` (map-merge overrides → package-relative `imports` rule) and `leaverou/restaurants` (`exclude` → `include: false`)

## LOC

Excluding tests, docs, and comments: **+461 / −174** (src only). Full diff: 20 files, +1262 / −394.

Docs PR: nudeps/nudeps.dev#2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
