### PR TITLE
Drop JSPM workarounds fixed by jspm/jspm#2745

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -27,10 +27,7 @@ export class ImportMapGenerator extends Generator {
 			flattenScopes: false,
 			combineSubpaths: false,
 			commonJS: true,
-			// Skip .d.ts files whose presence in wildcard exports causes
-			// JSPM trace failures (jspm/jspm#2717, #122).
-			ignore: specifier =>
-				getNodeBuiltins().includes(specifier) || /\.d\.[cm]?ts(\.map)?$/.test(specifier),
+			ignore: specifier => getNodeBuiltins().includes(specifier),
 			...generatorOptions,
 		});
 
@@ -48,9 +45,8 @@ export class ImportMapGenerator extends Generator {
 
 		// Patch package configs before JSPM resolves them:
 		// 1. Apply community overrides (client-side equivalent of what jspm.io CDN does server-side)
-		// 2. Strip non-runtime export conditions that shadow `default` in wildcards (#126)
+		// 2. Strip non-runtime export conditions JSPM enumerates but won't resolve
 		let pm = this.provider;
-		let { env } = this.traceMap.resolver;
 		pm._getPackageConfig = pm.getPackageConfig;
 		pm.getPackageConfig = async function (pkgUrl) {
 			let pcfg = await pm._getPackageConfig(pkgUrl);
@@ -62,7 +58,7 @@ export class ImportMapGenerator extends Generator {
 			}
 
 			if (pcfg?.exports) {
-				pcfg.exports = stripConditions(pcfg.exports, env);
+				pcfg.exports = stripConditions(pcfg.exports);
 			}
 
 			return pcfg;

--- a/src/util/jspm-overrides.js
+++ b/src/util/jspm-overrides.js
@@ -13,40 +13,30 @@ export { overrides };
 const EXPORT_CONDITIONS_BLACKLIST = ["types", "typings"];
 
 /**
- * Strip export conditions that would shadow `default` in JSPM's wildcard
- * resolution (jspm/jspm#2717). At each object level:
- * - If any sibling is known (in `conditions` or is `default`), drop the unknown
- *   siblings — JSPM has a resolution to pick, the rest get in the way.
- * - Otherwise leave the object alone; we can't tell which condition would resolve.
- *
- * `types`/`typings` are always stripped: they resolve to `.d.ts` files which
- * break JSPM tracing even when they're the only condition.
+ * Strip non-runtime export conditions before JSPM sees them.
+ * A subpath exported *only* under one of these has no runtime resolution,
+ * so JSPM enumerates it but then refuses to resolve it, failing the install.
+ * @see https://github.com/jspm/jspm/issues/2751
  * @param {import("@jspm/generator").ExportsTarget} exports
- * @param {string[]} conditions - Recognized export conditions (JSPM resolver env)
  * @returns {import("@jspm/generator").ExportsTarget}
  */
-export function stripConditions (exports, conditions) {
+export function stripConditions (exports) {
 	if (!exports || typeof exports !== "object") {
 		return exports;
 	}
 
 	if (Array.isArray(exports)) {
 		// Fallback array: strip each alternative
-		return exports.map(item => stripConditions(item, conditions));
+		return exports.map(stripConditions);
 	}
-
-	let hasKnown = Object.keys(exports).some(key => key === "default" || conditions.includes(key));
 
 	let ret = {};
 	for (let key in exports) {
-		if (
-			EXPORT_CONDITIONS_BLACKLIST.includes(key) ||
-			(hasKnown && key !== "default" && !conditions.includes(key))
-		) {
+		if (EXPORT_CONDITIONS_BLACKLIST.includes(key)) {
 			continue;
 		}
 
-		ret[key] = stripConditions(exports[key], conditions);
+		ret[key] = stripConditions(exports[key]);
 	}
 
 	return ret;

--- a/test/util/jspm-overrides.js
+++ b/test/util/jspm-overrides.js
@@ -2,10 +2,17 @@ import { stripConditions } from "../../src/util/jspm-overrides.js";
 
 export default {
 	name: "stripConditions",
-	run: exports => stripConditions(exports, ["production", "browser", "module", "import"]),
+	run: stripConditions,
 	tests: [
 		{
-			name: "Strips types condition shadowing default (#126)",
+			name: "Empties a subpath exported only under a type condition",
+			description:
+				"Left in, JSPM enumerates the subpath but then refuses to resolve it, aborting the batch and silently dropping the subpaths after it.",
+			arg: { "./types": { import: { types: "./index.d.ts" } } },
+			expect: { "./types": { import: {} } },
+		},
+		{
+			name: "Drops types from nested conditions, keeping the runtime target",
 			arg: {
 				"./src/*": {
 					import: {
@@ -45,12 +52,7 @@ export default {
 			},
 		},
 		{
-			name: "Allowlist mode drops unknown conditions in favor of default",
-			arg: { "./x": { deno: "./d.js", default: "./def.js" } },
-			expect: { "./x": { default: "./def.js" } },
-		},
-		{
-			name: "Blocklist mode keeps unknowns but still drops types/typings",
+			name: "Keeps unknown conditions but still drops types/typings",
 			arg: { "./x": { deno: "./d.js", types: "./d.ts", typings: "./d2.ts" } },
 			expect: { "./x": { deno: "./d.js" } },
 		},


### PR DESCRIPTION
Drops the workarounds fixed upstream by jspm/jspm#2745. Closes #156.

> [!WARNING]
> **Do not merge yet.** #2745 is merged but unreleased — latest `@jspm/generator` is 2.16.3 (2026-06-29); the fix landed [2026-08-17](https://github.com/jspm/jspm/commit/078ff060380557e0903044475435f7fd41834051). Merge only together with a bump to 2.16.4+. On 2.16.3 this removal breaks colorjs.io, zod and idb.

## Removed

**`.d.ts` ignore filter** (#122) — declarations now trace as dependency-free upstream.

**Condition-shadowing logic in `stripConditions`** (#126) — the generator now resolves strictly before speculating:

```json
"./sub/*": { "deno": "./deno/*", "default": "./src/*" }
```

Before: enumerated `deno/` filenames, resolved via `default` → `Module not found`. Now: `./src/`.

## Still standing

`types`/`typings` stripping. #2745 still enumerates targets reachable only under unknown conditions — [its own test asserts this](https://github.com/jspm/jspm/blob/078ff060380557e0903044475435f7fd41834051/generator/src/common/package.test.ts#L466-L476) — while `resolvePackageTarget` stays strict and refuses them.

Real packages with the shape: [ts-pattern@5.9.0](https://github.com/gvergnaud/ts-pattern/blob/0e15315eafbbb813a91bad34496418846981c1b1/package.json#L21-L29) and [es-toolkit@1.52.0](https://github.com/toss/es-toolkit/blob/32f4c8fb33828ad6512064ba84b0fdd8fda966a3/package.json#L305-L312) — a `./types` subpath with no runtime target:

```json
"./types": { "import": { "types": "./dist/types/index.d.ts" } }
```

→ `No './types' exports subpath defined`. `install()` catches it and retries with `subpaths: false`, so we degrade rather than throw — on both packages the resulting map still came out complete, so the observable cost today is a wasted retry plus a spurious "Failed to trace subpaths" warning. Stripping keeps us off that fallback path entirely.

Reported upstream as jspm/jspm#2751 — fixing that retires `stripConditions` for good.

## Verification

Built jspm `main` at [`078ff06`](https://github.com/jspm/jspm/commit/078ff060380557e0903044475435f7fd41834051) from source; it passes the generator's own `package.test.js`. Against 17 packages plus fixtures: the `.d.ts` filter produces identical maps on/off, the shadowing logic is unnecessary, and the `types` stripping is what keeps `subpaths: true` working.

`.map` was dropped from the filter's regex deliberately — declaration maps trace as `format=esm, deps=[]` (JSON, no imports the lexer can see, including inside `sourcesContent`), and the only export shape that enumerates them condenses to a trailing-slash prefix.

Not verified: the demo import-map diff, which needs a `@jspm/generator` version that doesn't exist yet. Worth running before merge.

| File | +/− (substantive) |
|---|---|
| `src/map.js` | +2 / −4 |
| `src/util/jspm-overrides.js` | +4 / −8 |
| `test/util/jspm-overrides.js` | +10 / −8 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oHRkng85emGDgo9x9Mxpm
