### PR TITLE
Resolve `cjs-browser-shim` through the lockfile

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -21,8 +21,13 @@ export class ImportMapGenerator extends Generator {
 	constructor ({ installCache, silent, nudeps, ...generatorOptions } = {}) {
 		let commonJS = generatorOptions.commonJS ?? true;
 
+		// nudeps provides the shim, so an entry point importing it must resolve through the
+		// lockfile — a linked nudeps keeps it out of the project's node_modules (#159).
+		let shim = nudeps?.packages.get("cjs-browser-shim");
+
 		super({
 			defaultProvider: "nodemodules",
+			resolutions: shim ? { "cjs-browser-shim": shim.path } : {},
 			env: ["production", "browser", "module"],
 			flattenScopes: false,
 			combineSubpaths: false,

--- a/test/map/index.js
+++ b/test/map/index.js
@@ -1,6 +1,17 @@
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
+import Packages from "../../src/util/packages.js";
 
 const FIXTURES = join(import.meta.dirname, "fixtures");
+
+// Stands in for Nudeps: the generator only reads lock data from it, and that is what locates the
+// shim when it lives under a linked nudeps instead of the project's node_modules.
+const nudeps = {
+	packages: new Packages({
+		packages: { "node_modules/cjs-browser-shim": { version: "0.0.1" } },
+	}),
+};
 
 export default {
 	name: "ImportMapGenerator.install()",
@@ -37,6 +48,33 @@ export default {
 				"Nothing to resolve here, so the retry throws and must swallow it: mapping nothing is the right answer, and an error would be a regression for CSS/font-only packages (#102).",
 			arg: "no-entry",
 			expect: [],
+		},
+		{
+			name: "Resolves an entry point's `cjs-browser-shim` import",
+			description:
+				"nudeps provides the shim, so it resolves through the lockfile — a linked nudeps leaves it out of the project's node_modules (#159). A temp directory reproduces that: nothing above it holds the shim.",
+			async run () {
+				let { ImportMapGenerator, ImportMap } = await import("../../src/map.js");
+				let dir = mkdtempSync(join(tmpdir(), "nudeps-shim-"));
+
+				try {
+					writeFileSync(
+						join(dir, "package.json"),
+						JSON.stringify({ name: "shim-repro", type: "module", main: "index.js" }),
+					);
+					writeFileSync(join(dir, "index.js"), `import "cjs-browser-shim";\n`);
+
+					let gen = new ImportMapGenerator({ nudeps });
+					await gen.install("shim-repro", dir, { noRetry: true });
+
+					// The shim resolves into a scope, so look at the whole map, not just imports.
+					return [...new ImportMap(gen)].map(entry => entry.specifier).sort();
+				}
+				finally {
+					rmSync(dir, { recursive: true, force: true });
+				}
+			},
+			expect: ["cjs-browser-shim", "shim-repro"],
 		},
 	],
 };


### PR DESCRIPTION
Closes #159. Stacked on #158 — review that first.

## The fix is two lines

```js
let shim = nudeps?.packages.get("cjs-browser-shim");
resolutions: shim ? { "cjs-browser-shim": shim.path } : {},
```

`cjs-browser-shim` is a specifier nudeps *provides*, not one the project installs — Node couldn't resolve it from the entry point under any install style. JSPM was looking for it in the project's `node_modules`, where a linked nudeps never puts it; a registry install only worked by accident of hoisting. JSPM's `resolutions` pins it before `nodeResolve` runs, using the same lockfile path `install()` already uses for the same package.

The issue diagnosed this as a sequencing gap. It isn't — nothing needs reordering, so `finalize()` is untouched.

## Effect

- `lodash`, `jquery` and `interactjs` demos no longer report `Failed to install root package`.
- Import maps are unchanged apart from those three gaining `"scopes": {}`, which the other demos already have.
- Bonus: under `--cjs=false` an entry importing the shim previously left it unmapped, breaking at runtime. Now mapped.
- Not fixed: #81. Its repro loses the error but react is still missing — `prune` skips direct deps and `require()` is invisible to static tracing.

The entry is inert when the shim is hoisted: `packages.get` returns the same path JSPM would find.

## Test

One case added to the existing `ImportMapGenerator.install()` table. The temp directory is what reproduces the bug — nothing above it holds the shim, as under `npm link`. Without the fix it fails with the issue's exact error; the other three cases still pass.

## Diff stats

Substantive lines, excluding blank-only and comment-only changes.

| File | + | − |
|---|---:|---:|
| `src/map.js` | 2 | 0 |
| `test/map/index.js` | 31 | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
