### PR TITLE
Skip untraceable subpaths instead of aborting the trace

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -12,6 +12,12 @@ import nudepsPkg from "../package.json" with { type: "json" };
  */
 
 export class ImportMapGenerator extends Generator {
+	/** Specifier of the package being installed, whose trace failure is fatal (unlike a subpath's). */
+	#mainEntry = null;
+
+	/** Wildcard-expanded subpaths dropped from the map. */
+	#skipped = new Set();
+
 	/**
 	 * @param {object} [options]
 	 * @param {object} [options.installCache] - Per-package output map cache (mutated on miss), or null
@@ -32,8 +38,8 @@ export class ImportMapGenerator extends Generator {
 			flattenScopes: false,
 			combineSubpaths: false,
 			commonJS: true,
-			// Skip .d.ts files whose presence in wildcard exports causes
-			// JSPM trace failures (jspm/jspm#2717, #122).
+			// Keep .d.ts files that wildcard exports expose out of the map — a browser has no
+			// use for them (jspm/jspm#2717, #122). Their trace failures are handled below.
 			ignore: specifier =>
 				getNodeBuiltins().includes(specifier) || /\.d\.[cm]?ts(\.map)?$/.test(specifier),
 			...generatorOptions,
@@ -72,6 +78,32 @@ export class ImportMapGenerator extends Generator {
 
 			return pcfg;
 		};
+
+		// Wildcard expansion is speculative: `"./*": "./*"` exposes files the author never
+		// promised are modules — prose, build scripts importing devDependencies. JSPM traces
+		// each expanded subpath independently, but one throw aborts the whole install, so an
+		// unrelated README.md cost `three` its real `three/addons` export (#160).
+		let tm = this.traceMap;
+		let { visit, extractMap } = tm;
+
+		tm.visit = (specifier, opts, parentUrl, seen) =>
+			// Only install()'s per-subpath calls omit `seen` — recursion and extractMap()'s
+			// re-walk pass it, and must stay strict. A subpath is a plain specifier, so visit()
+			// always resolves it asynchronously; `?.` degrades to the old abort if that changes.
+			seen !== undefined || specifier === this.#mainEntry
+				? visit.call(tm, specifier, opts, parentUrl, seen)
+				: visit.call(tm, specifier, opts, parentUrl)?.catch?.(() => {
+						this.#skipped.add(specifier);
+					});
+
+		// JSPM pins a subpath once its trace resolves, so a skipped one has to be unpinned here
+		// — its trace is incomplete, and extractMap() would rethrow the error we just swallowed.
+		tm.extractMap = (pins, ...rest) =>
+			extractMap.call(
+				tm,
+				pins.filter(pin => !this.#skipped.has(pin)),
+				...rest,
+			);
 	}
 
 	get provider () {
@@ -119,6 +151,8 @@ export class ImportMapGenerator extends Generator {
 		}
 
 		// Not cacheable (root package, symlink, etc.): install on this generator
+		this.#mainEntry = alias;
+		let skippedBefore = this.#skipped.size;
 		try {
 			let ret = await super.install({
 				alias,
@@ -126,6 +160,16 @@ export class ImportMapGenerator extends Generator {
 				subpaths: true,
 				...installOptions,
 			});
+
+			// #skipped is cumulative (extractMap() keeps filtering earlier pins), so report the delta
+			let skipped = [...this.#skipped].slice(skippedBefore);
+			if (skipped.length && !this.silent) {
+				// A `./*` export can expose hundreds of files, so name only a few
+				let rest = skipped.splice(3);
+				console.warn(
+					`[nudeps] Skipped untraceable subpaths in ${alias}: ${skipped.join(", ")}${rest.length ? `, +${rest.length} more` : ""}.`,
+				);
+			}
 
 			// Resolving nothing isn't an error to JSPM, so a package with neither `main` nor
 			// `exports` — no subpaths to enumerate, implicit index.js gone with them — would

--- a/test/e2e/issue-160.js
+++ b/test/e2e/issue-160.js
@@ -1,0 +1,65 @@
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const NUDEPS_ROOT = resolve(import.meta.dirname, "../..");
+
+export default {
+	name: "An unparseable file doesn't cost a package its declared exports (issue #160)",
+	description:
+		"https://github.com/nudeps/nudeps/issues/160 — a `./*` export hands JSPM every file in the " +
+		"package, and one that fails to trace used to abort the install: `three` lost `three/addons`.",
+	async run () {
+		let dir = mkdtempSync(join(tmpdir(), "nudeps-issue-160-"));
+		try {
+			let dep = join(dir, "wildcard-dep");
+			mkdirSync(dep);
+			writeFileSync(
+				join(dep, "package.json"),
+				JSON.stringify({
+					name: "wildcard-dep",
+					version: "1.0.0",
+					type: "module",
+					exports: { ".": "./index.js", "./extra": "./extra.js", "./*": "./*" },
+				}),
+			);
+			writeFileSync(join(dep, "index.js"), "export const main = 1;\n");
+			writeFileSync(join(dep, "extra.js"), "export const extra = 2;\n");
+
+			// The two ways a wildcard-exposed file fails to trace: unparseable, and parseable but
+			// importing something absent. The second only fails once its own deps are walked, so it
+			// also covers the transitive case — a skipped subpath must not resurface via a survivor.
+			writeFileSync(join(dep, "BROKEN.md"), "# Changelog\n\nimport {\n");
+			writeFileSync(join(dep, "build.js"), `import "never-installed-package";\n`);
+
+			writeFileSync(
+				join(dir, "package.json"),
+				JSON.stringify({
+					name: "issue-160-repro",
+					version: "1.0.0",
+					type: "module",
+					main: "index.js",
+					dependencies: { "wildcard-dep": "file:./wildcard-dep" },
+					devDependencies: { nudeps: `file:${NUDEPS_ROOT}` },
+				}),
+			);
+			writeFileSync(join(dir, "index.js"), `import "wildcard-dep";\n`);
+
+			let env = { ...process.env, npm_config_audit: "false", npm_config_fund: "false" };
+			let exec = cmd => execSync(cmd, { cwd: dir, env, stdio: "ignore" });
+
+			exec("npm install");
+			exec("npx nudeps");
+
+			let map = readFileSync(join(dir, "importmap.js"), "utf8");
+			// Sorted: the map's key order isn't what's under test
+			return [...map.matchAll(/"(wildcard-dep[^"]*)":/g)].map(([, s]) => s).sort();
+		}
+		finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	},
+	// `wildcard-dep/extra` is what disappears when one bad file aborts the trace
+	expect: ["wildcard-dep", "wildcard-dep/", "wildcard-dep/extra"],
+};


### PR DESCRIPTION
Closes #160.

A `"./*"` export hands JSPM every file in the package. JSPM traces each expanded subpath independently and pins it only after success — *"we do this after the trace, so failed installs don't pollute the map"*, per its own comment — but the `Promise.all` over those subpaths has no per-entry boundary, so one throw takes the rest with it.

`three` was losing two documented exports over a README:

```diff
+ "three/addons": "./client_modules/three@0.175.0/examples/jsm/Addons.js"
+ "three/tsl":    "./client_modules/three@0.175.0/build/three.tsl.js"
```

## The fix

Restore the boundary JSPM already intends: tolerate a failed subpath, and drop it from `pins` — `extractMap()` re-walks every pin and would otherwise rethrow the error we just swallowed. The main entry stays fatal, so a package with no usable entry point still falls back to `subpaths: false` and errors as before (#30, #144 depend on that).

Skipped subpaths are now named instead of hidden behind a trace error:

```
[nudeps] Skipped untraceable subpaths in three: three/examples/fonts/ttf/README.md, …, +14 more.
```

## Why not an extension filter

The trace is fail-fast, so the reported error is only the first blocker. `open-props` has seven, across two mechanisms:

| blocker | why it fails |
|---|---|
| `CHANGELOG.md`, `readme.md` | prose; es-module-lexer parse error |
| `build/bundle-sizes.js` | imports `brotli-size` |
| `build/props.js`, `build/to-resolver.js`, `src/props.colors.src.js` | import `colorjs.io` |
| `postcss.config.cjs` | imports `cssnano` |

All four packages are `open-props` devDependencies — declared, never installed in a consumer's tree. No extension test classifies those.

This also covers #122 ("Named subpath exports lost when wildcard trace fails"), which was closed with a `.d.ts`-only workaround. That filter stays, but for map hygiene rather than trace failures — removing it adds a `gsap/types/` entry no browser can use, so its comment was corrected to say so.

Reported upstream on jspm/jspm#2751, which already names this `Promise.all` but frames the fix as aligning enumeration with resolution — both triggers here are correctly enumerated targets, so they survive that. The atomicity is JSPM's, so this stays deletable (#156).

`visit` and `extractMap` are both non-`private` in `@jspm/generator`'s shipped `.d.ts`, alongside `traceMap`, `pins` and `resolver.pm` — JSPM marks its actual internals (`_visitFromResolve`, `_fanout`, `_extractMapAsync`) private. `visit` is declared `string | null | undefined | Promise<…>`, so `?.catch?.()` handles the documented union rather than an observed shape.

## Verification

`212/212` unit, e2e incl. the new `issue-160` regression test (fails without the fix: `["wildcard-dep", "wildcard-dep/"]` — `wildcard-dep/extra` gone). Across `npm run init-demos`: `three/addons` and `three/tsl` restored, error lines 8 → 0, every other demo's map byte-identical, and no change to what lands in `client_modules` in any of the 14 demos.

Also re-run against the local testbed's 9 project setups — monorepo/workspace, deploy-to-`dist`, chained and sibling local deps: all 12 generated maps and every output tree byte-identical, with `basic` and `deployed` trading four lines of JSPM parse-error spew for one line naming what was skipped.

| file | +/- (substantive) |
|---|---|
| `src/map.js` | +27 / -0 |
| `test/e2e/issue-160.js` | +53 / -0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

