### PR TITLE
Fail on unknown CLI subcommands

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -5,10 +5,21 @@ import readArgs from "./args.js";
 
 let args = readArgs();
 
-if (process.argv.includes("install")) {
+// The subcommand is the first argument; a leading dash makes it a flag, so there is no subcommand
+let [command] = process.argv.slice(2);
+if (command?.startsWith("-")) {
+	command = undefined;
+}
+
+if (command === "install") {
 	await install();
 	await nudeps({ ...args, init: true });
 }
-else {
+else if (command === undefined) {
 	await nudeps(args);
+}
+else {
+	// A typo, or a subcommand from a newer nudeps, must not silently regenerate the map
+	console.error(`[nudeps] Unknown command: ${command}`);
+	process.exitCode = 1;
 }


### PR DESCRIPTION
Closes #165.

`src/cli/index.js` dispatched with `process.argv.includes(...)` and a bare `else`, so an unrecognised command ran the **default** action, and a command name anywhere in argv — including as a flag's value — ran that command.

```sh
npx nudeps buildd          # regenerated importmap.js, exit 0
npx nudeps --dir install   # ran the `install` command
```

The command is now the first argument, ignored when it starts with a dash, and anything unrecognised exits non-zero:

```
[nudeps] Unknown command: buildd
```

The message deliberately doesn't list valid commands — that list would need updating every time one is added, and #166 adds one.

`process.exitCode` rather than `process.exit()`: stderr is async when piped, and `process.exit()` truncates it.

## The issue's flag-value repro is wrong

#165 gives `npx nudeps --dir=install`. That form never triggered it — `--dir=install` is one argv element and `includes("install")` compares elements exactly. The space-separated `npx nudeps --dir install` is the real trigger, verified against the pre-fix dispatch: exit 0, with hooks written into `package.json`.

## Rebasing #166

#166 adds a `dependents` subcommand to this dispatch and will rebase cleanly into a half-fixed state — its `else if (process.argv.includes("dependents"))` survives untouched and needs to become `else if (command === "dependents")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
