### PR TITLE
Create the new parent before moving `dir`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,9 @@ export default async function (options) {
 				rmSync(oldConfig.dir, { recursive: true });
 			}
 			else {
+				// renameSync needs the destination's parent, and a consumer that clears
+				// its output directory before building has just deleted it (#152)
+				mkdirSync(path.dirname(config.dir), { recursive: true });
 				renameSync(oldConfig.dir, config.dir);
 			}
 		}


### PR DESCRIPTION
Closes #152.

`renameSync` requires the destination's parent to exist, and nothing created it. For a consumer that clears its output directory before building, that parent has just been deleted, so every run after a `dir` change died — with an ENOENT naming the *source*, which reads as though the old directory were missing.

```
Error: ENOENT: no such file or directory, rename 'assets/deps' -> '_site/assets/deps'
```

Only the rename path needed this. The sibling `if (config.init)` branch deletes `oldConfig.dir` instead of renaming, so `config.dir` doesn't exist afterwards and `createGitignoredDir(config.dir)` creates it downstream — that's `mkdirSync(dir, { recursive: true })` (`src/util/fs.js:145`), which already creates parents.

Verified by repro: with the line removed, the ENOENT above; with it, `4 copied in _site/assets/deps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
